### PR TITLE
dockerfile: disable `CGO_ENABLED`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY go.mod go.sum ./
 RUN go mod download && go mod verify
 
 COPY . .
-RUN go build -v -o . ./...
+RUN CGO_ENABLED=0 go build -v -o . ./...
 
 # Final stage
 FROM debian:bookworm-slim


### PR DESCRIPTION
Fixes #38 

Looking at the dependencies of the project, none of them require CGO enabled. This flag is causing the build to panic and crash out.