### PR TITLE
feat(readme): improve configuration and Docker usage documentation; add example config.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ profile.cov
 
 # ignore the binary
 watchdog
+
+# Avoid Committing Configuration File
+config.json

--- a/README.md
+++ b/README.md
@@ -11,25 +11,40 @@ Go 1.23 or higher
 ## Configuration
 
 The watchdog service can be configured using either:
+
 - A **local JSON configuration file** (`--config-file`).
 - A **remote JSON configuration URL** (`--config-url`).
+  - Using a remote configuration allows you to dynamically add, remove, or update server configurations at runtime.
 
 ### JSON Configuration Format
 
-The JSON configuration file should contain an array of `ObaServer` objects. Example:
+The JSON configuration file should contain an array of `ObaServer` objects, each representing an OBA server to be monitored. Example:
 
 ```json
 [
   {
-    "name": "Test Server",
+    "name": "Test Server 1",
     "id": 1,
-    "oba_base_url": "https://test.example.com",
-    "oba_api_key": "test-key",
-    "gtfs_url": "https://gtfs.example.com",
-    "trip_update_url": "https://trip.example.com",
-    "vehicle_position_url": "https://vehicle.example.com",
-    "gtfs_rt_api_key": "api-key",
-    "gtfs_rt_api_value": "api-value"
+    "oba_base_url": "https://test1.example.com",
+    "oba_api_key": "test-key-1",
+    "gtfs_url": "https://gtfs1.example.com",
+    "trip_update_url": "https://trip1.example.com",
+    "vehicle_position_url": "https://vehicle1.example.com",
+    "gtfs_rt_api_key": "api-key-1",
+    "gtfs_rt_api_value": "api-value-1",
+    "agency_id": "agency-1"
+  },
+  {
+    "name": "Test Server 2",
+    "id": 2,
+    "oba_base_url": "https://test2.example.com",
+    "oba_api_key": "test-key-2",
+    "gtfs_url": "https://gtfs2.example.com",
+    "trip_update_url": "https://trip2.example.com",
+    "vehicle_position_url": "https://vehicle2.example.com",
+    "gtfs_rt_api_key": "api-key-2",
+    "gtfs_rt_api_value": "api-value-2",
+    "agency_id": "agency-2"
   }
 ]
 ```
@@ -46,8 +61,10 @@ export SENTRY_DSN="your_sentry_dsn"
 
 #### **Using a Local Configuration File**
 
+Update the `config.json` file with your actual OBA server configuration, then run the following command:
+
 ```bash
-go run ./cmd/watchdog/ --config-file /path/to/your/config.json
+go run ./cmd/watchdog/ --config-file ./config.json
 ```
 
 ## **Using a Remote Configuration URL with Authentication**
@@ -55,6 +72,7 @@ go run ./cmd/watchdog/ --config-file /path/to/your/config.json
 To load the configuration from a remote URL that requires basic authentication, follow these steps:
 
 ### 1. **Set the Required Environment Variables**
+
 Before running the application, set the `CONFIG_AUTH_USER` and `CONFIG_AUTH_PASS` environment variables with the username and password for authentication.
 
 #### On Linux/macOS:
@@ -71,10 +89,9 @@ set CONFIG_AUTH_USER=your_username
 set CONFIG_AUTH_PASS=your_password
 ```
 
-####  Run the Application with the Remote URL
+#### Run the Application with the Remote URL
 
- Use the --config-url flag to specify the remote configuration URL. For example:
-
+Use the --config-url flag to specify the remote configuration URL. For example:
 
 ```bash
 go run ./cmd/watchdog/ \
@@ -86,6 +103,7 @@ go run ./cmd/watchdog/ \
 You can also run the application using Docker. Here’s how:
 
 ### 1. **Build the Docker Image**
+
 First, build the Docker image for the application. Navigate to the root of the project directory and run:
 
 ```bash
@@ -94,17 +112,34 @@ docker build -t watchdog .
 
 ### 2. **Run the Docker Container**
 
+#### 2.1 **Using Local Config**
+
 ```bash
 docker run -d \
   --name watchdog \
   -e CONFIG_AUTH_USER=admin \
   -e CONFIG_AUTH_PASS=password \
-  -p 3000:3000 \
+  -v ./config.json:/app/config.json \
+  -p 4000:4000 \
+  watchdog \
+  --config-file /app/config.json
+```
+
+#### 2.2 **Using Remote Config**
+
+```bash
+docker run -d \
+  --name watchdog \
+  -e CONFIG_AUTH_USER=admin \
+  -e CONFIG_AUTH_PASS=password \
+  -p 4000:4000 \
   watchdog \
   --config-url http://example.com/config.json
 ```
 
 # Testing
+
+To run all unit tests:
 
 ```
 go test ./...

--- a/config.json
+++ b/config.json
@@ -1,0 +1,26 @@
+[
+  {
+    "name": "Test Server 1",
+    "id": 1,
+    "oba_base_url": "https://test1.example.com",
+    "oba_api_key": "test-key-1",
+    "gtfs_url": "https://gtfs1.example.com",
+    "trip_update_url": "https://trip1.example.com",
+    "vehicle_position_url": "https://vehicle1.example.com",
+    "gtfs_rt_api_key": "api-key-1",
+    "gtfs_rt_api_value": "api-value-1",
+    "agency_id": "agency-1"
+  },
+  {
+    "name": "Test Server 2",
+    "id": 2,
+    "oba_base_url": "https://test2.example.com",
+    "oba_api_key": "test-key-2",
+    "gtfs_url": "https://gtfs2.example.com",
+    "trip_update_url": "https://trip2.example.com",
+    "vehicle_position_url": "https://vehicle2.example.com",
+    "gtfs_rt_api_key": "api-key-2",
+    "gtfs_rt_api_value": "api-value-2",
+    "agency_id": "agency-2"
+  }
+]


### PR DESCRIPTION
This PR enhances the README documentation and project setup by:

- Clarifying the configuration section
- Adding an example `config.json` file with two servers to demonstrate multi-server support
- Updating the "Running using local config file" section to reference the example `config.json` in the repo
- Adding instructions for running the application with Docker using a local configuration file
- Fixing Docker usage instructions for remote configuration files
- Adding `config.json` to `.gitignore` to prevent the contributors from accidental commits of local configuration changes
