### PR TITLE
Add Sentry Middleware and Improve Error Reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,7 @@ go.work.sum
 profile.cov
 
 # ignore the binary
-watchdog
+/watchdog
 
 # Avoid Committing Configuration File
 config.json

--- a/cmd/watchdog/main.go
+++ b/cmd/watchdog/main.go
@@ -88,6 +88,7 @@ func main() {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 
 	setupSentry()
+	defer sentry.Flush(2 * time.Second)
 
 	cacheDir := "cache"
 	if err = createCacheDirectory(cacheDir, logger); err != nil {
@@ -263,8 +264,6 @@ func setupSentry() {
 	}); err != nil {
 		log.Fatalf("sentry.Init: %s", err)
 	}
-
-	defer sentry.Flush(2 * time.Second)
 
 	sentry.CaptureMessage("Watchdog started")
 

--- a/cmd/watchdog/middleware.go
+++ b/cmd/watchdog/middleware.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/getsentry/sentry-go/http"
+)
+
+func sentryMiddleware(next http.Handler) http.Handler {
+	sentryHandler := sentryhttp.New(sentryhttp.Options{
+		Repanic:         true,
+		WaitForDelivery: true,
+		Timeout:         2 * time.Second,
+	})
+
+	return sentryHandler.Handle(next)
+}

--- a/cmd/watchdog/routes.go
+++ b/cmd/watchdog/routes.go
@@ -18,6 +18,7 @@ func (app *application) routes() http.Handler {
 	router.HandlerFunc(http.MethodGet, "/v1/healthcheck", app.healthcheckHandler)
 	router.Handler(http.MethodGet, "/metrics", promhttp.Handler())
 
-	// Return the httprouter instance.
-	return router
+	// Wrap router with Sentry middleware
+	// Return wrapped httprouter instance.
+	return sentryMiddleware(router)
 }

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.23.5
 
 require (
 	github.com/OneBusAway/go-sdk v0.1.0-alpha.13
-	github.com/getsentry/sentry-go v0.31.1
+	github.com/getsentry/sentry-go v0.33.0
 	github.com/jamespfennell/gtfs v0.1.24
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/prometheus/client_golang v1.20.5

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/getsentry/sentry-go v0.31.1 h1:ELVc0h7gwyhnXHDouXkhqTFSO5oslsRDk0++eyE0KJ4=
 github.com/getsentry/sentry-go v0.31.1/go.mod h1:CYNcMMz73YigoHljQRG+qPF+eMq8gG72XcGN/p71BAY=
+github.com/getsentry/sentry-go v0.33.0 h1:YWyDii0KGVov3xOaamOnF0mjOrqSjBqwv48UEzn7QFg=
+github.com/getsentry/sentry-go v0.33.0/go.mod h1:C55omcY9ChRQIUcVcGcs+Zdy4ZpQGvNJ7JYHIoSWOtE=
 github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=
 github.com/go-errors/errors v1.4.2/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=


### PR DESCRIPTION
- Added Sentry middleware to wrap httprouter for error tracking
- Ensured Sentry flushes before application exit
- Updated go.mod and go.sum for latest Sentry version
- Modified routes.go to return the middleware-wrapped router
- Refined .gitignore to exclude only the watchdog binary