### PR TITLE
Refactor Sentry error reporting pattern with flexible options across application layers

### DIFF
--- a/cmd/watchdog/main.go
+++ b/cmd/watchdog/main.go
@@ -186,9 +186,7 @@ func downloadGTFSBundles(servers []models.ObaServer, cacheDir string, logger *sl
 		_, err := utils.DownloadGTFSBundle(server.GtfsUrl, cacheDir, server.ID, hashStr)
 		if err != nil {
 			reporter.ReportErrorWithSentryOptions(err, report.SentryReportOptions{
-				Tags: map[string]string{
-					"server_id": fmt.Sprintf("%d", server.ID),
-				},
+				Tags: utils.MakeMap("server_id", fmt.Sprintf("%d", server.ID)),
 				ExtraContext: map[string]interface{}{
 					"gtfs_url": server.GtfsUrl,
 				},
@@ -216,9 +214,7 @@ func refreshConfig(configURL, configAuthUser, configAuthPass string, app *applic
 		newServers, err := loadConfigFromURL(configURL, configAuthUser, configAuthPass, reporter)
 		if err != nil {
 			reporter.ReportErrorWithSentryOptions(err, report.SentryReportOptions{
-				Tags: map[string]string{
-					"config_url": configURL,
-				},
+				Tags:  utils.MakeMap("config_url", configURL),
 				Level: sentry.LevelError,
 			})
 			logger.Error("Failed to refresh remote config", "error", err)
@@ -241,9 +237,7 @@ func loadConfigFromFile(filePath string, reporter *report.Reporter) ([]models.Ob
 	data, err := os.ReadFile(filePath)
 	if err != nil {
 		reporter.ReportErrorWithSentryOptions(err, report.SentryReportOptions{
-			Tags: map[string]string{
-				"file_path": filePath,
-			},
+			Tags:  utils.MakeMap("file_path", filePath),
 			Level: sentry.LevelError,
 		})
 		return nil, fmt.Errorf("failed to read config file: %v", err)
@@ -252,9 +246,7 @@ func loadConfigFromFile(filePath string, reporter *report.Reporter) ([]models.Ob
 	var servers []models.ObaServer
 	if err := json.Unmarshal(data, &servers); err != nil {
 		reporter.ReportErrorWithSentryOptions(err, report.SentryReportOptions{
-			Tags: map[string]string{
-				"file_path": filePath,
-			},
+			Tags:  utils.MakeMap("file_path", filePath),
 			Level: sentry.LevelError,
 		})
 		return nil, fmt.Errorf("failed to unmarshal JSON: %v", err)
@@ -268,9 +260,7 @@ func loadConfigFromURL(url, authUser, authPass string, reporter *report.Reporter
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		reporter.ReportErrorWithSentryOptions(err, report.SentryReportOptions{
-			Tags: map[string]string{
-				"config_url": url,
-			},
+			Tags:  utils.MakeMap("config_url", url),
 			Level: sentry.LevelError,
 		})
 		return nil, fmt.Errorf("failed to create request: %v", err)
@@ -283,9 +273,7 @@ func loadConfigFromURL(url, authUser, authPass string, reporter *report.Reporter
 	resp, err := client.Do(req)
 	if err != nil {
 		reporter.ReportErrorWithSentryOptions(err, report.SentryReportOptions{
-			Tags: map[string]string{
-				"config_url": url,
-			},
+			Tags:  utils.MakeMap("config_url", url),
 			Level: sentry.LevelError,
 		})
 		return nil, fmt.Errorf("failed to fetch remote config: %v", err)
@@ -295,9 +283,7 @@ func loadConfigFromURL(url, authUser, authPass string, reporter *report.Reporter
 	if resp.StatusCode != http.StatusOK {
 		statusErr := fmt.Errorf("remote config returned status: %d", resp.StatusCode)
 		reporter.ReportErrorWithSentryOptions(statusErr, report.SentryReportOptions{
-			Tags: map[string]string{
-				"config_url": url,
-			},
+			Tags:  utils.MakeMap("config_url", url),
 			Level: sentry.LevelError,
 		})
 		return nil, statusErr
@@ -306,9 +292,7 @@ func loadConfigFromURL(url, authUser, authPass string, reporter *report.Reporter
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		reporter.ReportErrorWithSentryOptions(err, report.SentryReportOptions{
-			Tags: map[string]string{
-				"config_url": url,
-			},
+			Tags:  utils.MakeMap("config_url", url),
 			Level: sentry.LevelError,
 		})
 		return nil, fmt.Errorf("failed to read remote config: %v", err)
@@ -317,9 +301,7 @@ func loadConfigFromURL(url, authUser, authPass string, reporter *report.Reporter
 	var servers []models.ObaServer
 	if err := json.Unmarshal(data, &servers); err != nil {
 		reporter.ReportErrorWithSentryOptions(err, report.SentryReportOptions{
-			Tags: map[string]string{
-				"config_url": url,
-			},
+			Tags:  utils.MakeMap("config_url", url),
 			Level: sentry.LevelError,
 		})
 		return nil, fmt.Errorf("failed to unmarshal JSON: %v", err)

--- a/cmd/watchdog/main_test.go
+++ b/cmd/watchdog/main_test.go
@@ -42,7 +42,7 @@ func TestLoadConfigFromFile(t *testing.T) {
 		}
 		tmpFile.Close()
 
-		servers, err := loadConfigFromFile(tmpFile.Name() , reporter)
+		servers, err := loadConfigFromFile(tmpFile.Name(), reporter)
 		if err != nil {
 			t.Fatalf("loadConfigFromFile failed: %v", err)
 		}
@@ -81,14 +81,14 @@ func TestLoadConfigFromFile(t *testing.T) {
 		}
 		tmpFile.Close()
 
-		_, err = loadConfigFromFile(tmpFile.Name() , reporter)
+		_, err = loadConfigFromFile(tmpFile.Name(), reporter)
 		if err == nil {
 			t.Errorf("Expected error with invalid JSON, got none")
 		}
 	})
 
 	t.Run("NonExistentFile", func(t *testing.T) {
-		_, err := loadConfigFromFile("non-existent-file.json" , reporter)
+		_, err := loadConfigFromFile("non-existent-file.json", reporter)
 		if err == nil {
 			t.Errorf("Expected error for non-existent file, got none")
 		}
@@ -113,7 +113,7 @@ func TestLoadConfigFromURL(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		servers, err := loadConfigFromURL(ts.URL, "user", "pass" , reporter)
+		servers, err := loadConfigFromURL(ts.URL, "user", "pass", reporter)
 		if err != nil {
 			t.Fatalf("loadConfigFromURL failed: %v", err)
 		}
@@ -143,7 +143,7 @@ func TestLoadConfigFromURL(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		_, err := loadConfigFromURL(ts.URL, "", "" , reporter)
+		_, err := loadConfigFromURL(ts.URL, "", "", reporter)
 		if err == nil {
 			t.Errorf("Expected error with 500 response, got none")
 		}
@@ -155,14 +155,14 @@ func TestLoadConfigFromURL(t *testing.T) {
 			w.Write([]byte(`{ this is not valid JSON }`))
 		}))
 		defer ts.Close()
-		
-		_, err := loadConfigFromURL(ts.URL, "", "" , reporter)
+
+		_, err := loadConfigFromURL(ts.URL, "", "", reporter)
 		if err == nil {
 			t.Errorf("Expected error for invalid JSON response, got none")
 		}
 	})
 	t.Run("InvalidURL", func(t *testing.T) {
-		_, err := loadConfigFromURL("://invalid-url", "", "" , reporter)
+		_, err := loadConfigFromURL("://invalid-url", "", "", reporter)
 		if err == nil || !strings.Contains(err.Error(), "failed to create request") {
 			t.Errorf("Expected request creation error, got: %v", err)
 		}
@@ -216,81 +216,78 @@ func parseFlags() (string, string, error) {
 	return *configFile, *configURL, nil
 }
 
-
-
-
 func TestValidateConfigFlags(t *testing.T) {
 	tests := []struct {
-			name        string
-			configFile  string
-			configURL   string
-			extraArgs   []string
-			expectError bool
+		name        string
+		configFile  string
+		configURL   string
+		extraArgs   []string
+		expectError bool
 	}{
-			{"No config", "", "", nil, false},
-			{"Valid local config", "config.json", "", nil, false},
-			{"Valid remote config", "", "http://example.com/config.json", nil, false},
-			{"Both config file and URL", "config.json", "http://example.com/config.json", nil, true},
-			{"Config file with extra args", "config.json", "", []string{"extraArg"}, true},
-			{"Config URL with extra args", "", "http://example.com/config.json", []string{"extraArg"}, true},
+		{"No config", "", "", nil, false},
+		{"Valid local config", "config.json", "", nil, false},
+		{"Valid remote config", "", "http://example.com/config.json", nil, false},
+		{"Both config file and URL", "config.json", "http://example.com/config.json", nil, true},
+		{"Config file with extra args", "config.json", "", []string{"extraArg"}, true},
+		{"Config URL with extra args", "", "http://example.com/config.json", []string{"extraArg"}, true},
 	}
 
 	for _, tt := range tests {
-			t.Run(tt.name, func(t *testing.T) {
-					flag.CommandLine = flag.NewFlagSet(tt.name, flag.ContinueOnError)
-					var output bytes.Buffer
-					flag.CommandLine.SetOutput(&output)
-					
-					configFile := flag.String("config-file", "", "Path to config file")
-					configURL := flag.String("config-url", "", "URL to config")
-					
-					args := []string{"cmd"}
-					if tt.configFile != "" {
-							args = append(args, "--config-file="+tt.configFile)
-					}
-					if tt.configURL != "" {
-							args = append(args, "--config-url="+tt.configURL) 
-					}
-					args = append(args, tt.extraArgs...)
-					
-					os.Args = args
-					flag.CommandLine.Parse(args[1:])
-					
-					err := validateConfigFlags(configFile, configURL)
-					
-					if (err != nil) != tt.expectError {
-							t.Errorf("Expected error: %v, got: %v", tt.expectError, err)
-					}
-					
-					if err != nil && !strings.Contains(err.Error(), "only one of --config-file or --config-url") {
-							t.Errorf("Unexpected error message: %v", err)
-					}
-			})
+		t.Run(tt.name, func(t *testing.T) {
+			flag.CommandLine = flag.NewFlagSet(tt.name, flag.ContinueOnError)
+			var output bytes.Buffer
+			flag.CommandLine.SetOutput(&output)
+
+			configFile := flag.String("config-file", "", "Path to config file")
+			configURL := flag.String("config-url", "", "URL to config")
+
+			args := []string{"cmd"}
+			if tt.configFile != "" {
+				args = append(args, "--config-file="+tt.configFile)
+			}
+			if tt.configURL != "" {
+				args = append(args, "--config-url="+tt.configURL)
+			}
+			args = append(args, tt.extraArgs...)
+
+			os.Args = args
+			flag.CommandLine.Parse(args[1:])
+
+			err := validateConfigFlags(configFile, configURL)
+
+			if (err != nil) != tt.expectError {
+				t.Errorf("Expected error: %v, got: %v", tt.expectError, err)
+			}
+
+			if err != nil && !strings.Contains(err.Error(), "only one of --config-file or --config-url") {
+				t.Errorf("Unexpected error message: %v", err)
+			}
+		})
 	}
 }
 
 func TestUpdateConfig(t *testing.T) {
 	app := &application{}
-	
+
 	initialServers := []models.ObaServer{
 		{ID: 1, Name: "Server 1"},
 	}
-	
+
 	newServers := []models.ObaServer{
 		{ID: 1, Name: "Server 1 Updated"},
 		{ID: 2, Name: "Server 2"},
 	}
-	
+
 	app.updateConfig(initialServers)
 	if len(app.config.Servers) != 1 {
 		t.Errorf("Expected 1 server, got %d", len(app.config.Servers))
 	}
-	
+
 	app.updateConfig(newServers)
 	if len(app.config.Servers) != 2 {
 		t.Errorf("Expected 2 servers, got %d", len(app.config.Servers))
 	}
-	
+
 	if app.config.Servers[0].Name != "Server 1 Updated" {
 		t.Errorf("Expected server name to be updated to 'Server 1 Updated', got %s", app.config.Servers[0].Name)
 	}
@@ -301,74 +298,73 @@ func TestCreateCacheDirectory(t *testing.T) {
 	reporter := report.NewReporter("test", "development")
 
 	t.Run("Creates new directory", func(t *testing.T) {
-			baseTempDir := t.TempDir()
-			tempDir := filepath.Join(baseTempDir, "test-cache")
-			
-			err := createCacheDirectory(tempDir, logger , reporter)
-			if err != nil {
-					t.Fatalf("Failed to create cache directory: %v", err)
-			}
-			
-			stat, err := os.Stat(tempDir)
-			if err != nil {
-					t.Fatalf("Failed to stat directory: %v", err)
-			}
-			if !stat.IsDir() {
-					t.Error("Cache directory was created but is not a directory")
-			}
+		baseTempDir := t.TempDir()
+		tempDir := filepath.Join(baseTempDir, "test-cache")
+
+		err := createCacheDirectory(tempDir, logger, reporter)
+		if err != nil {
+			t.Fatalf("Failed to create cache directory: %v", err)
+		}
+
+		stat, err := os.Stat(tempDir)
+		if err != nil {
+			t.Fatalf("Failed to stat directory: %v", err)
+		}
+		if !stat.IsDir() {
+			t.Error("Cache directory was created but is not a directory")
+		}
 	})
-	
+
 	t.Run("Handles existing directory", func(t *testing.T) {
-			baseTempDir := t.TempDir()
-			tempDir := filepath.Join(baseTempDir, "test-cache")
-			
-			if err := os.MkdirAll(tempDir, os.ModePerm); err != nil {
-					t.Fatalf("Failed to create test directory: %v", err)
-			}
-			
-			err := createCacheDirectory(tempDir, logger , reporter)
-			if err != nil {
-					t.Errorf("Failed on existing directory: %v", err)
-			}
+		baseTempDir := t.TempDir()
+		tempDir := filepath.Join(baseTempDir, "test-cache")
+
+		if err := os.MkdirAll(tempDir, os.ModePerm); err != nil {
+			t.Fatalf("Failed to create test directory: %v", err)
+		}
+
+		err := createCacheDirectory(tempDir, logger, reporter)
+		if err != nil {
+			t.Errorf("Failed on existing directory: %v", err)
+		}
 	})
-	
+
 	t.Run("Fails: if path is a file", func(t *testing.T) {
-			baseTempDir := t.TempDir()
-			filePath := filepath.Join(baseTempDir, "test-file")
-			
-			if file, err := os.Create(filePath); err != nil {
-					t.Fatalf("Failed to create test file: %v", err)
-			} else {
-					file.Close()
-			}
-			
-			err := createCacheDirectory(filePath, logger , reporter)
-			if err == nil {
-					t.Error("Expected error when path is a file, but got nil")
-			}
+		baseTempDir := t.TempDir()
+		filePath := filepath.Join(baseTempDir, "test-file")
+
+		if file, err := os.Create(filePath); err != nil {
+			t.Fatalf("Failed to create test file: %v", err)
+		} else {
+			file.Close()
+		}
+
+		err := createCacheDirectory(filePath, logger, reporter)
+		if err == nil {
+			t.Error("Expected error when path is a file, but got nil")
+		}
 	})
-	
 
 }
 
 func TestRefreshConfig(t *testing.T) {
 	app := newTestApplication(t)
-	
+
 	testLogger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	reporter := report.NewReporter("test", "development")
 
 	var serverHitCount int
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			serverHitCount++
-			
-			user, pass, hasAuth := r.BasicAuth()
-			if hasAuth && (user != "testuser" || pass != "testpass") {
-					w.WriteHeader(http.StatusUnauthorized)
-					return
-			}
-			
-			w.Header().Set("Content-Type", "application/json")
-			fmt.Fprintln(w, `[
+		serverHitCount++
+
+		user, pass, hasAuth := r.BasicAuth()
+		if hasAuth && (user != "testuser" || pass != "testpass") {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintln(w, `[
 					{
 							"id": 999,
 							"name": "Refreshed Test Server",
@@ -379,36 +375,36 @@ func TestRefreshConfig(t *testing.T) {
 			]`)
 	}))
 	defer mockServer.Close()
-	
+
 	originalConfig := make([]models.ObaServer, len(app.config.Servers))
 	copy(originalConfig, app.config.Servers)
-	
-	go refreshConfig(mockServer.URL, "testuser", "testpass", app, testLogger, 100*time.Millisecond , reporter)
-	
+
+	go refreshConfig(mockServer.URL, "testuser", "testpass", app, testLogger, 100*time.Millisecond, reporter)
+
 	time.Sleep(200 * time.Millisecond)
-	
+
 	if serverHitCount == 0 {
-			t.Fatal("Mock server was never called")
+		t.Fatal("Mock server was never called")
 	}
-	
+
 	app.mu.RLock()
 	updatedServers := app.config.Servers
 	app.mu.RUnlock()
-	
+
 	if len(updatedServers) == 0 {
-			t.Fatal("No servers found in updated configuration")
+		t.Fatal("No servers found in updated configuration")
 	}
-	
+
 	var found bool
 	for _, s := range updatedServers {
-			if s.ID == 999 && s.Name == "Refreshed Test Server" {
-					found = true
-					break
-			}
+		if s.ID == 999 && s.Name == "Refreshed Test Server" {
+			found = true
+			break
+		}
 	}
-	
+
 	if !found {
-    t.Errorf("Config not updated with refreshed server data. Original: %+v, Updated: %+v", originalConfig, updatedServers)
+		t.Errorf("Config not updated with refreshed server data. Original: %+v, Updated: %+v", originalConfig, updatedServers)
 	}
 }
 
@@ -416,13 +412,13 @@ func TestDownloadGTFSBundles(t *testing.T) {
 	servers := []models.ObaServer{
 		{ID: 1, GtfsUrl: "https://example.com/gtfs.zip"},
 	}
-	
+
 	tempDir := t.TempDir()
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	reporter := report.NewReporter("test", "development")
-	
-	downloadGTFSBundles(servers, tempDir, logger , reporter)
-	
+
+	downloadGTFSBundles(servers, tempDir, logger, reporter)
+
 }
 
 func TestRefreshGTFSBundles(t *testing.T) {
@@ -432,10 +428,10 @@ func TestRefreshGTFSBundles(t *testing.T) {
 
 	servers := []models.ObaServer{{ID: 1, Name: "Test Server", GtfsUrl: "http://example.com/gtfs.zip"}}
 	cacheDir := t.TempDir()
-	
-	go refreshGTFSBundles(servers, cacheDir, logger, 10*time.Millisecond , reporter)
-	
-	time.Sleep(15*time.Millisecond)
-	
+
+	go refreshGTFSBundles(servers, cacheDir, logger, 10*time.Millisecond, reporter)
+
+	time.Sleep(15 * time.Millisecond)
+
 	t.Log("refreshGTFSBundles executed without crashing")
 }

--- a/cmd/watchdog/metrics_test.go
+++ b/cmd/watchdog/metrics_test.go
@@ -43,12 +43,12 @@ func TestMetricsEndpoint(t *testing.T) {
 
 func TestCollectMetricsForServer(t *testing.T) {
 	app := newTestApplication(t)
-	
+
 	prometheus.DefaultRegisterer = prometheus.NewRegistry()
-	
+
 	testServer := app.config.Servers[0]
-	
+
 	app.collectMetricsForServer(testServer)
-	
+
 	getMetricsForTesting(t, metrics.ObaApiStatus)
 }

--- a/internal/report/reporter.go
+++ b/internal/report/reporter.go
@@ -7,7 +7,6 @@ import (
 	"github.com/getsentry/sentry-go"
 )
 
-
 // Reporter provides methods to configure Sentry and report errors
 // with environment-specific metadata (like env, version, arch, etc.).
 type Reporter struct {
@@ -29,7 +28,7 @@ func (r *Reporter) ConfigureScope() {
 		scope.SetTag("env", r.Env)
 		scope.SetTag("app_version", r.Version)
 		scope.SetTag("go_version", runtime.Version())
-		scope.SetTag("goarch", runtime.GOARCH) 
+		scope.SetTag("goarch", runtime.GOARCH)
 		scope.SetContext("host_info", map[string]interface{}{
 			"hostname": r.getHostname(),
 		})
@@ -45,7 +44,6 @@ func (r *Reporter) getHostname() string {
 	}
 	return hostname
 }
-
 
 // ReportError reports the error to Sentry with the given severity level
 // If no level is provided, it defaults to sentry.LevelError.
@@ -64,7 +62,6 @@ func (r *Reporter) ReportError(err error, levels ...sentry.Level) {
 		sentry.CaptureException(err)
 	})
 }
-
 
 // SentryReportOptions provides optional data for reporting.
 type SentryReportOptions struct {

--- a/internal/report/sentry.go
+++ b/internal/report/sentry.go
@@ -20,7 +20,6 @@ func SetupSentry() {
 	sentry.CaptureMessage("Watchdog started")
 }
 
-
 func FlushSentry() {
 	sentry.Flush(2 * time.Second)
 }

--- a/internal/utils/helpers.go
+++ b/internal/utils/helpers.go
@@ -1,0 +1,5 @@
+package utils
+
+func MakeMap(key, value string) map[string]string {
+	return map[string]string{key: value}
+}

--- a/internal/utils/helpers.go
+++ b/internal/utils/helpers.go
@@ -1,5 +1,6 @@
 package utils
 
+// MakeMap creates and returns a map[string]string containing a single key-value pair.
 func MakeMap(key, value string) map[string]string {
 	return map[string]string{key: value}
 }


### PR DESCRIPTION

* Refactored Sentry reporting to use a unified `SentryReportOptions` for passing tags, context, and severity level
* Introduced `ReportErrorWithSentryOptions` to replace ad-hoc reporting calls with a consistent helper
* Improved `ConfigureScope` to include `goarch` and renamed `version` tag to `app_version`
* Renamed `ReportIfProd` → `ReportError` 
* Updated main application flow to consistently use the `Reporter` with the new pattern (GTFS download, config loading, cache creation)
* Integrated Sentry reporting into `collectMetricsForServer`
* Enhanced tests in `main_test.go` for Reporter integration