### PR TITLE
Add TripMatchRatio and StopMatchRatio Metrics to Prometheus

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -120,6 +120,16 @@ var (
 		[]string{"server", "agency"},
 	)
 
+	TripMatchRatio = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "oba_realtime_trip_match_ratio",
+		Help: "Ratio of matched realtime trips to total realtime trips",
+	}, []string{"server", "agency"})
+
+	StopMatchRatio = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "oba_stop_match_ratio",
+		Help: "Ratio of matched stops to total stops",
+	}, []string{"server", "agency"})
+
 	ObaTimeSinceUpdate = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "oba_time_since_last_update_seconds",

--- a/internal/metrics/oba_rest_api_metrics.go
+++ b/internal/metrics/oba_rest_api_metrics.go
@@ -106,6 +106,14 @@ func FetchObaAPIMetrics(slugID string, serverBaseUrl string, apiKey string, clie
 			ObaRealtimeTripsUnmatched.WithLabelValues(slugID, agencyID).Set(float64(count))
 		}
 
+		matched := entry.RealtimeTripCountsMatched[agencyID]
+		unmatched := entry.RealtimeTripCountsUnmatched[agencyID]
+		total := matched + unmatched
+		if total > 0 {
+			ratio := float64(matched) / float64(total)
+			TripMatchRatio.WithLabelValues(slugID, agencyID).Set(ratio)
+		}
+
 		if count, ok := entry.ScheduledTripsCount[agencyID]; ok {
 			ObaScheduledTrips.WithLabelValues(slugID, agencyID).Set(float64(count))
 		}
@@ -116,6 +124,14 @@ func FetchObaAPIMetrics(slugID string, serverBaseUrl string, apiKey string, clie
 
 		if count, ok := entry.StopIDsUnmatchedCount[agencyID]; ok {
 			ObaStopsUnmatched.WithLabelValues(slugID, agencyID).Set(float64(count))
+		}
+
+		stopMatched := entry.StopIDsMatchedCount[agencyID]
+		stopUnmatched := entry.StopIDsUnmatchedCount[agencyID]
+		stopTotal := stopMatched + stopUnmatched
+		if stopTotal > 0 {
+			stopRatio := float64(stopMatched) / float64(stopTotal)
+			StopMatchRatio.WithLabelValues(slugID, agencyID).Set(stopRatio)
 		}
 
 		if seconds, ok := entry.TimeSinceLastRealtimeUpdate[agencyID]; ok {


### PR DESCRIPTION
## Changes
* Implement logic to calculate `TripMatchRatio` and `StopMatchRatio`
* Register and expose both metrics to Prometheus
Here is a corrected and polished version of your text:

---

## Statistical Analysis

The following statistical insights can be derived from the exposed metrics using PromQL and visualized in Grafana:

1. **`sum(oba_realtime_trips_unmatched_count)`**

   * Returns the total number of unmatched trips across all servers and agencies.
   * Useful for setting alerts if the number of unmatched trips exceeds a critical **_threshold_**.

2. **`avg(oba_realtime_trip_match_ratio) by (server, agency)`**

   * Calculates the average `trip_match_ratio` per agency on each server.
   * Can be simplified to `avg(oba_realtime_trip_match_ratio) by (server)` to get the overall average per server.

3. **`delta(oba_realtime_trips_unmatched_count[5m])`**

   * Shows the raw change in unmatched trip count over a 5-minute window.
   * Helps detect sudden spikes or drops in unmatched trips.

4. **`delta(oba_realtime_trip_match_ratio[1h])`**

   * Measures the change in `trip_match_ratio` over the past hour.
   * Useful for identifying gradual degradation or improvement over time.

---


