### PR TITLE
Expose unmatched stop locations from GTFS static data

### DIFF
--- a/internal/app/metrics_collector.go
+++ b/internal/app/metrics_collector.go
@@ -90,7 +90,7 @@ func (app *Application) CollectMetricsForServer(server models.ObaServer) {
 		})
 	}
 
-	err = metrics.FetchObaAPIMetrics(server.AgencyID, server.ObaBaseURL, server.ObaApiKey, nil)
+	err = metrics.FetchObaAPIMetrics(server.AgencyID, server.ID, server.ObaBaseURL, server.ObaApiKey, nil)
 
 	if err != nil {
 		app.Logger.Error("Failed to fetch OBA API metrics", "error", err)

--- a/internal/gtfs/gtfs_bundles.go
+++ b/internal/gtfs/gtfs_bundles.go
@@ -9,9 +9,11 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"time"
 
 	"github.com/getsentry/sentry-go"
+	"github.com/jamespfennell/gtfs"
 	"watchdog.onebusaway.org/internal/models"
 	"watchdog.onebusaway.org/internal/report"
 	"watchdog.onebusaway.org/internal/utils"
@@ -71,4 +73,79 @@ func DownloadGTFSBundle(url string, cacheDir string, serverID int, hashStr strin
 	}
 
 	return cachePath, nil
+}
+
+// ParseGTFSFromCache reads a GTFS bundle from the cache and parses it into a gtfs.Static object.
+// It returns the parsed static data or an error if parsing fails.
+func ParseGTFSFromCache(cachePath string, serverID int) (*gtfs.Static, error) {
+	file, err := os.Open(cachePath)
+	if err != nil {
+		report.ReportErrorWithSentryOptions(err, report.SentryReportOptions{
+			Tags: utils.MakeMap("server_id", strconv.Itoa(serverID)),
+			ExtraContext: map[string]interface{}{
+				"cache_path": cachePath,
+			},
+		})
+		return nil, err
+	}
+	defer file.Close()
+
+	// Convert the file into a byte slice
+	fileInfo, err := file.Stat()
+	if err != nil {
+		report.ReportErrorWithSentryOptions(err, report.SentryReportOptions{
+			Tags: utils.MakeMap("server_id", strconv.Itoa(serverID)),
+			ExtraContext: map[string]interface{}{
+				"cache_path": cachePath,
+			},
+		})
+		return nil, err
+	}
+
+	fileBytes := make([]byte, fileInfo.Size())
+	if _, err = file.Read(fileBytes); err != nil {
+		report.ReportErrorWithSentryOptions(err, report.SentryReportOptions{
+			Tags: utils.MakeMap("server_id", strconv.Itoa(serverID)),
+			ExtraContext: map[string]interface{}{
+				"cache_path": cachePath,
+			},
+		})
+		return nil, err
+	}
+
+	staticData, err := gtfs.ParseStatic(fileBytes, gtfs.ParseStaticOptions{})
+	if err != nil {
+		report.ReportErrorWithSentryOptions(err, report.SentryReportOptions{
+			Tags: utils.MakeMap("server_id", strconv.Itoa(serverID)),
+			ExtraContext: map[string]interface{}{
+				"cache_path": cachePath,
+			},
+		})
+		return nil, err
+	}
+
+	return staticData, nil
+}
+
+// GetStopLocationsByIDs retrieves stop locations by their IDs from the GTFS cache.
+// It returns a map of stop IDs to gtfs.Stop objects.
+
+func GetStopLocationsByIDs(cachePath string, serverID int, stopIDs []string) (map[string]gtfs.Stop, error) {
+	staticData, err := ParseGTFSFromCache(cachePath, serverID)
+	if err != nil {
+		return nil, err
+	}
+
+	stopIDSet := make(map[string]struct{}, len(stopIDs))
+	for _, id := range stopIDs {
+		stopIDSet[id] = struct{}{}
+	}
+
+	result := make(map[string]gtfs.Stop)
+	for _, stop := range staticData.Stops {
+		if _, exists := stopIDSet[stop.Id]; exists {
+			result[stop.Id] = stop
+		}
+	}
+	return result, nil
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -137,4 +137,12 @@ var (
 		},
 		[]string{"server", "agency"},
 	)
+
+	ObaUnmatchedStopLocation = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "oba_unmatched_stop_location",
+			Help: "Location info of unmatched stops from static GTFS",
+		},
+		[]string{"server", "agency", "stop_id", "stop_name", "lat", "lon"},
+	)
 )

--- a/internal/metrics/oba_rest_api_metrics_test.go
+++ b/internal/metrics/oba_rest_api_metrics_test.go
@@ -13,6 +13,7 @@ func TestFetchObaAPIMetrics_WithVCR(t *testing.T) {
 	tests := []struct {
 		name      string
 		slugID    string
+		serverID  int
 		serverUrl string
 		apiKey    string
 		useVCR    bool
@@ -23,6 +24,7 @@ func TestFetchObaAPIMetrics_WithVCR(t *testing.T) {
 		{
 			name:      "successful request",
 			slugID:    "unitrans",
+			serverID:  1,
 			serverUrl: "https://oba-api.onrender.com",
 			apiKey:    "org.onebusaway.iphone",
 			useVCR:    true,
@@ -32,6 +34,7 @@ func TestFetchObaAPIMetrics_WithVCR(t *testing.T) {
 		{
 			name:      "not found error",
 			slugID:    "invalid-region",
+			serverID:  2,
 			serverUrl: "https://api.pugetsound.onebusaway.org",
 			apiKey:    "org.onebusaway.iphone",
 			useVCR:    false,
@@ -57,7 +60,7 @@ func TestFetchObaAPIMetrics_WithVCR(t *testing.T) {
 				}
 			}
 
-			err := FetchObaAPIMetrics(tt.slugID, tt.serverUrl, tt.apiKey, client)
+			err := FetchObaAPIMetrics(tt.slugID, tt.serverID, tt.serverUrl, tt.apiKey, client)
 
 			if tt.wantErr {
 				if err == nil {


### PR DESCRIPTION
* Refactored GTFS parsing logic into `ParseGTFSFromCache`
   * will open another PR to refactor the function that parses GTFS bundles
* Added `GetStopLocationsByIDs` to map stop IDs to lat/lon
* Introduced `ObaUnmatchedStopLocation` Prometheus metric
* Updated `FetchObaAPIMetrics` to expose unmatched stop locations
* Added unit tests for new GTFS utility functions

