### PR TITLE
feat(metrics): track vehicle reporting frequency 

### DIFF
--- a/internal/app/metrics_collector.go
+++ b/internal/app/metrics_collector.go
@@ -105,4 +105,15 @@ func (app *Application) CollectMetricsForServer(server models.ObaServer) {
 			Level: sentry.LevelError,
 		})
 	}
+	err = metrics.TrackVehicleReportingFrequency(server)
+	if err != nil {
+		app.Logger.Error("Failed to track vehicle reporting frequency", "error", err)
+		report.ReportErrorWithSentryOptions(err, report.SentryReportOptions{
+			Tags: map[string]string{
+				"server_id": fmt.Sprintf("%d", server.ID),
+			},
+			Level: sentry.LevelError,
+		})
+	}
+
 }

--- a/internal/metrics/agencies_with_coverage.go
+++ b/internal/metrics/agencies_with_coverage.go
@@ -52,17 +52,14 @@ func CheckAgenciesWithCoverage(cachePath string, logger *slog.Logger, server mod
 
 	staticData, err := gtfs.ParseStatic(fileBytes, gtfs.ParseStaticOptions{})
 	if err != nil {
-		if err != nil {
-			report.ReportErrorWithSentryOptions(err, report.SentryReportOptions{
-				Tags: map[string]string{
-					"server_id": strconv.Itoa(server.ID),
-				},
-				ExtraContext: map[string]interface{}{
-					"cache_path": cachePath,
-				},
-			})
-			return 0, err
-		}
+		report.ReportErrorWithSentryOptions(err, report.SentryReportOptions{
+			Tags: map[string]string{
+				"server_id": strconv.Itoa(server.ID),
+			},
+			ExtraContext: map[string]interface{}{
+				"cache_path": cachePath,
+			},
+		})
 		return 0, err
 	}
 
@@ -124,6 +121,10 @@ func CheckAgenciesWithCoverageMatch(cachePath string, logger *slog.Logger, serve
 	}
 
 	coverageAgenciesCount, err := GetAgenciesWithCoverage(server)
+
+	if err != nil {
+		return fmt.Errorf("error getting remote agencies with coverage data: %w", err)
+	}
 
 	matchValue := 0
 	if coverageAgenciesCount == staticGtfsAgenciesCount {

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -60,6 +60,16 @@ var (
 		Name: "vehicle_count_match",
 		Help: "Whether the number of vehicles in the API response matches the number of vehicles in the static GTFS-RT file (1 = match, 0 = no match)",
 	}, []string{"agency_id", "server_id"})
+
+	VehicleReportInterval = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "vehicle_position_report_interval_seconds",
+		Help: "Time in seconds since each vehicle last reported a GTFS-RT position",
+	}, []string{"vehicle_id", "server_id"})
+
+	VehicleReportCount = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "vehicle_report_total",
+		Help: "Total number of GTFS-RT updates received from each vehicle",
+	}, []string{"vehicle_id", "server_id"})
 )
 
 // OBA REST API 2.6.0 >= Metrics

--- a/internal/metrics/oba_rest_api_metrics.go
+++ b/internal/metrics/oba_rest_api_metrics.go
@@ -161,6 +161,9 @@ func FetchObaAPIMetrics(slugID string, serverID int, serverBaseUrl string, apiKe
 			}
 
 			for stopID, stop := range stopInfoMap {
+				if stop.Latitude == nil || stop.Longitude == nil {
+					continue
+				}
 				ObaUnmatchedStopLocation.WithLabelValues(
 					slugID,
 					agencyID,


### PR DESCRIPTION
- Added `vehicle_report_total` counter to track total number of GTFS-RT messages received per vehicle
- Added `vehicle_position_report_interval_seconds` gauge to track time since each vehicle last reported
- Added `FetchGTFSRTFeed` utility in `gtfs_bundles.go` to retrieve GTFS-RT feeds
- Registered new metrics in `metrics.go` and integrated into the existing metrics collection funciton
- Implemented `TrackVehicleReportingFrequency` function.