### PR TITLE
refactor: unify GTFS parsing and real-time fetching across coverage and vehicle checks

### DIFF
--- a/internal/app/metrics_collector.go
+++ b/internal/app/metrics_collector.go
@@ -46,7 +46,7 @@ func (app *Application) CollectMetricsForServer(server models.ObaServer) {
 		return
 	}
 
-	_, _, err = metrics.CheckBundleExpiration(cachePath, app.Logger, time.Now(), server)
+	_, _, err = metrics.CheckBundleExpiration(cachePath, time.Now(), server)
 	if err != nil {
 		app.Logger.Error("Failed to check GTFS bundle expiration", "error", err)
 		report.ReportErrorWithSentryOptions(err, report.SentryReportOptions{

--- a/internal/metrics/agencies_with_coverage.go
+++ b/internal/metrics/agencies_with_coverage.go
@@ -14,7 +14,7 @@ import (
 	"watchdog.onebusaway.org/internal/report"
 )
 
-func CheckAgenciesWithCoverage(cachePath string, logger *slog.Logger, server models.ObaServer) (int, error) {
+func CheckAgenciesWithCoverage(cachePath string, server models.ObaServer) (int, error) {
 	staticData, err := gtfs.ParseGTFSFromCache(cachePath, server.ID)
 	if err != nil {
 		return 0, fmt.Errorf("error parsing GTFS from cache: %w", err)
@@ -72,7 +72,7 @@ func GetAgenciesWithCoverage(server models.ObaServer) (int, error) {
 }
 
 func CheckAgenciesWithCoverageMatch(cachePath string, logger *slog.Logger, server models.ObaServer) error {
-	staticGtfsAgenciesCount, err := CheckAgenciesWithCoverage(cachePath, logger, server)
+	staticGtfsAgenciesCount, err := CheckAgenciesWithCoverage(cachePath, server)
 	if err != nil {
 		return err
 	}

--- a/internal/metrics/agencies_with_coverage.go
+++ b/internal/metrics/agencies_with_coverage.go
@@ -15,7 +15,7 @@ import (
 )
 
 func CheckAgenciesWithCoverage(cachePath string, logger *slog.Logger, server models.ObaServer) (int, error) {
-	staticData, err := gtfs.ParseGTFSFromCache(cachePath , server.ID)
+	staticData, err := gtfs.ParseGTFSFromCache(cachePath, server.ID)
 	if err != nil {
 		return 0, fmt.Errorf("error parsing GTFS from cache: %w", err)
 	}

--- a/internal/metrics/bundle_expiration.go
+++ b/internal/metrics/bundle_expiration.go
@@ -2,7 +2,6 @@ package metrics
 
 import (
 	"fmt"
-	"log/slog"
 	"strconv"
 	"time"
 
@@ -14,7 +13,7 @@ import (
 )
 
 // CheckBundleExpiration calculates the number of days remaining until the GTFS bundle expires.
-func CheckBundleExpiration(cachePath string, logger *slog.Logger, currentTime time.Time, server models.ObaServer) (int, int, error) {
+func CheckBundleExpiration(cachePath string, currentTime time.Time, server models.ObaServer) (int, int, error) {
 	staticData, err := gtfs.ParseGTFSFromCache(cachePath, server.ID)
 	if err != nil {
 		return 0, 0, err

--- a/internal/metrics/bundle_expiration_test.go
+++ b/internal/metrics/bundle_expiration_test.go
@@ -1,8 +1,6 @@
 package metrics
 
 import (
-	"log/slog"
-	"os"
 	"testing"
 	"time"
 )
@@ -13,8 +11,7 @@ func TestCheckBundleExpiration(t *testing.T) {
 
 	testServer := createTestServer("www.example.com", "Test Server", 999, "", "www.example.com", "test-api-value", "test-api-key", "1")
 
-	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
-	earliest, latest, err := CheckBundleExpiration(fixturePath, logger, fixedTime, testServer)
+	earliest, latest, err := CheckBundleExpiration(fixturePath, fixedTime, testServer)
 	if err != nil {
 		t.Fatalf("CheckBundleExpiration failed: %v", err)
 	}

--- a/internal/metrics/gtfs-realtime-bindings.go
+++ b/internal/metrics/gtfs-realtime-bindings.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"net/http"
-	"net/url"
 	"strconv"
 	"time"
 
@@ -20,38 +18,8 @@ import (
 )
 
 func CountVehiclePositions(server models.ObaServer) (int, error) {
-	parsedURL, err := url.Parse(server.VehiclePositionUrl)
+	resp, err := gtfs.FetchGTFSRTFeed(server)
 	if err != nil {
-		err = fmt.Errorf("failed to parse GTFS-RT URL: %v", err)
-		report.ReportErrorWithSentryOptions(err, report.SentryReportOptions{
-			Tags: utils.MakeMap("server_id", strconv.Itoa(server.ID)),
-			ExtraContext: map[string]interface{}{
-				"vehicle_position_url": server.VehiclePositionUrl,
-			},
-		})
-		return 0, err
-	}
-
-	req, err := http.NewRequest("GET", parsedURL.String(), nil)
-	if err != nil {
-		err = fmt.Errorf("failed to create HTTP request: %v", err)
-		report.ReportError(err)
-		return 0, err
-	}
-	if server.GtfsRtApiKey != "" && server.GtfsRtApiValue != "" {
-		req.Header.Set(server.GtfsRtApiKey, server.GtfsRtApiValue)
-	}
-
-	client := &http.Client{}
-	resp, err := client.Do(req)
-	if err != nil {
-		err = fmt.Errorf("failed to fetch GTFS-RT feed: %v", err)
-		report.ReportErrorWithSentryOptions(err, report.SentryReportOptions{
-			Tags: utils.MakeMap("server_id", strconv.Itoa(server.ID)),
-			ExtraContext: map[string]interface{}{
-				"vehicle_position_url": server.VehiclePositionUrl,
-			},
-		})
 		return 0, err
 	}
 	defer resp.Body.Close()


### PR DESCRIPTION
* Refactored `CheckAgenciesWithCoverage` and `CheckBundleExpiration` to use `ParseGTFSFromCache` for consistent static GTFS parsing.
* Updated `CountVehiclePositions` to use `FetchGTFSRTFeed` for standardized real-time feed retrieval.