### PR TITLE
feat: validate GTFS-RT vehicle coordinates using static GTFS bounding box

### DIFF
--- a/cmd/watchdog/main.go
+++ b/cmd/watchdog/main.go
@@ -89,22 +89,21 @@ func main() {
 		os.Exit(1)
 	}
 
-	store := geo.NewBoundingBoxStore()
+	boundingBoxStore := geo.NewBoundingBoxStore()
 
 	// Download GTFS bundles for all servers on startup
-	gtfs.DownloadGTFSBundles(servers, cacheDir, logger, store)
+	gtfs.DownloadGTFSBundles(servers, cacheDir, logger, boundingBoxStore)
 
 	app := &app.Application{
-		Config:           cfg,
-		Logger:           logger,
-		Version:          version,
-		BoundingBoxStore: store,
+		Config:  cfg,
+		Logger:  logger,
+		Version: version,
 	}
 
-	app.StartMetricsCollection()
+	app.StartMetricsCollection(boundingBoxStore)
 
 	// Cron job to download GTFS bundles for all servers every 24 hours
-	go gtfs.RefreshGTFSBundles(servers, cacheDir, logger, 24*time.Hour, store)
+	go gtfs.RefreshGTFSBundles(servers, cacheDir, logger, 24*time.Hour, boundingBoxStore)
 
 	// If a remote URL is specified, refresh the configuration every minute
 	if *configURL != "" {

--- a/cmd/watchdog/main.go
+++ b/cmd/watchdog/main.go
@@ -24,9 +24,6 @@ import (
 // number as a hard-coded global constant.
 const version = "1.0.0"
 
-// Define an application struct to hold the dependencies for our HTTP handlers, helpers,
-// and middleware. At the moment this only contains a copy of the config struct and a
-// logger, but it will grow to include a lot more as our build progresses.
 
 func main() {
 	var cfg server.Config

--- a/cmd/watchdog/main.go
+++ b/cmd/watchdog/main.go
@@ -95,9 +95,10 @@ func main() {
 	gtfs.DownloadGTFSBundles(servers, cacheDir, logger, store)
 
 	app := &app.Application{
-		Config:  cfg,
-		Logger:  logger,
-		Version: version,
+		Config:           cfg,
+		Logger:           logger,
+		Version:          version,
+		BoundingBoxStore: store,
 	}
 
 	app.StartMetricsCollection()

--- a/cmd/watchdog/main.go
+++ b/cmd/watchdog/main.go
@@ -89,21 +89,22 @@ func main() {
 		os.Exit(1)
 	}
 
-	boundingBoxStore := geo.NewBoundingBoxStore()
+	store := geo.NewBoundingBoxStore()
 
 	// Download GTFS bundles for all servers on startup
-	gtfs.DownloadGTFSBundles(servers, cacheDir, logger, boundingBoxStore)
+	gtfs.DownloadGTFSBundles(servers, cacheDir, logger, store)
 
 	app := &app.Application{
-		Config:  cfg,
-		Logger:  logger,
-		Version: version,
+		Config:           cfg,
+		Logger:           logger,
+		Version:          version,
+		BoundingBoxStore: store,
 	}
 
-	app.StartMetricsCollection(boundingBoxStore)
+	app.StartMetricsCollection()
 
 	// Cron job to download GTFS bundles for all servers every 24 hours
-	go gtfs.RefreshGTFSBundles(servers, cacheDir, logger, 24*time.Hour, boundingBoxStore)
+	go gtfs.RefreshGTFSBundles(servers, cacheDir, logger, 24*time.Hour, store)
 
 	// If a remote URL is specified, refresh the configuration every minute
 	if *configURL != "" {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -9,7 +9,15 @@ import (
 	"watchdog.onebusaway.org/internal/server"
 )
 
-// Application struct holds the configuration, logger, reporter, and version for the watchdog application.
+// Application holds the shared dependencies for HTTP handlers, helpers, and middleware.
+// 
+// Fields:
+// - Config: The application configuration.
+// - Logger: Structured logger used across the app.
+// - Version: The current version of the application.
+// - BoundingBoxStore: Responsible for calculating and storing bounding boxes for GTFS stops.
+//
+// This struct will expand as more components and dependencies are added during development.
 type Application struct {
 	Config           server.Config
 	Logger           *slog.Logger

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -4,18 +4,16 @@ import (
 	"log/slog"
 	"sync"
 
-	"watchdog.onebusaway.org/internal/geo"
 	"watchdog.onebusaway.org/internal/models"
 	"watchdog.onebusaway.org/internal/server"
 )
 
 // Application struct holds the configuration, logger, reporter, and version for the watchdog application.
 type Application struct {
-	Config           server.Config
-	Logger           *slog.Logger
-	Mu               sync.RWMutex
-	Version          string
-	BoundingBoxStore *geo.BoundingBoxStore
+	Config  server.Config
+	Logger  *slog.Logger
+	Mu      sync.RWMutex
+	Version string
 }
 
 // updateConfig safely updates the application's server configuration.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -4,16 +4,18 @@ import (
 	"log/slog"
 	"sync"
 
+	"watchdog.onebusaway.org/internal/geo"
 	"watchdog.onebusaway.org/internal/models"
 	"watchdog.onebusaway.org/internal/server"
 )
 
 // Application struct holds the configuration, logger, reporter, and version for the watchdog application.
 type Application struct {
-	Config  server.Config
-	Logger  *slog.Logger
-	Mu      sync.RWMutex
-	Version string
+	Config           server.Config
+	Logger           *slog.Logger
+	Mu               sync.RWMutex
+	Version          string
+	BoundingBoxStore *geo.BoundingBoxStore
 }
 
 // updateConfig safely updates the application's server configuration.

--- a/internal/app/metrics_collector.go
+++ b/internal/app/metrics_collector.go
@@ -116,4 +116,15 @@ func (app *Application) CollectMetricsForServer(server models.ObaServer) {
 		})
 	}
 
+	err = metrics.CountInvalidVehicleCoordinates(server, app.BoundingBoxStore)
+	if err != nil {
+		app.Logger.Error("Failed to count invalid vehicle coordinates", "error", err)
+		report.ReportErrorWithSentryOptions(err, report.SentryReportOptions{
+			Tags: map[string]string{
+				"server_id": fmt.Sprintf("%d", server.ID),
+			},
+			Level: sentry.LevelError,
+		})
+	}
+
 }

--- a/internal/app/metrics_collector.go
+++ b/internal/app/metrics_collector.go
@@ -116,7 +116,7 @@ func (app *Application) CollectMetricsForServer(server models.ObaServer) {
 		})
 	}
 
-	err = metrics.CountInvalidVehicleCoordinates(server, app.BoundingBoxStore)
+	err = metrics.TrackInvalidAndOutOfBoundsVehicles(server, app.BoundingBoxStore)
 	if err != nil {
 		app.Logger.Error("Failed to count invalid vehicle coordinates", "error", err)
 		report.ReportErrorWithSentryOptions(err, report.SentryReportOptions{

--- a/internal/app/metrics_collector.go
+++ b/internal/app/metrics_collector.go
@@ -116,7 +116,7 @@ func (app *Application) CollectMetricsForServer(server models.ObaServer) {
 		})
 	}
 
-	err = metrics.TrackInvalidAndOutOfBoundsVehicles(server, app.BoundingBoxStore)
+	err = metrics.TrackInvalidVehiclesAndStoppedOutOfBounds(server, app.BoundingBoxStore)
 	if err != nil {
 		app.Logger.Error("Failed to count invalid vehicle coordinates", "error", err)
 		report.ReportErrorWithSentryOptions(err, report.SentryReportOptions{

--- a/internal/app/metrics_collector_test.go
+++ b/internal/app/metrics_collector_test.go
@@ -8,8 +8,6 @@ import (
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"watchdog.onebusaway.org/internal/geo"
-	"watchdog.onebusaway.org/internal/gtfs"
 	"watchdog.onebusaway.org/internal/metrics"
 )
 
@@ -50,25 +48,7 @@ func TestCollectMetricsForServer(t *testing.T) {
 
 	testServer := app.Config.Servers[0]
 
-	const cachePath = "../../testdata/gtfs.zip"
-	staticData, err := gtfs.ParseGTFSFromCache(cachePath, testServer.ID)
-	if err != nil {
-		t.Fatalf("Failed to parse GTFS data: %v", err)
-	}
-	if staticData == nil {
-		t.Fatal("Parsed GTFS data is nil")
-	}
-
-	stops := staticData.Stops
-	boundingBox, err := geo.ComputeBoundingBox(stops)
-
-	if err != nil {
-		t.Fatalf("Failed to compute bounding box: %v", err)
-	}
-	boundingBoxStore := geo.NewBoundingBoxStore()
-	boundingBoxStore.Set(testServer.ID, boundingBox)
-
-	app.CollectMetricsForServer(testServer, boundingBoxStore)
+	app.CollectMetricsForServer(testServer)
 
 	getMetricsForTesting(t, metrics.ObaApiStatus)
 }

--- a/internal/geo/geo_utils.go
+++ b/internal/geo/geo_utils.go
@@ -1,0 +1,108 @@
+package geo
+
+import (
+	"fmt"
+	"math"
+	"sync"
+
+	"github.com/jamespfennell/gtfs"
+)
+
+// BoundingBox defines the corners of a lat/lon box
+type BoundingBox struct {
+	MinLat float64
+	MaxLat float64
+	MinLon float64
+	MaxLon float64
+}
+
+// Contains checks whether the given latitude and longitude are within the bounding box
+func (b *BoundingBox) Contains(lat, lon float64) bool {
+	return lat >= b.MinLat && lat <= b.MaxLat && lon >= b.MinLon && lon <= b.MaxLon
+}
+
+// ComputeBoundingBox computes the bounding box of all stops in static GTFS
+func ComputeBoundingBox(stops []gtfs.Stop) (BoundingBox, error) {
+	if len(stops) == 0 {
+		return BoundingBox{}, fmt.Errorf("no stops to compute bounding box")
+	}
+
+	minLat := math.MaxFloat64
+	maxLat := -math.MaxFloat64
+	minLon := math.MaxFloat64
+	maxLon := -math.MaxFloat64
+
+	for _, stop := range stops {
+		if stop.Latitude != nil && stop.Longitude != nil {
+			lat := float64(*stop.Latitude)
+			lon := float64(*stop.Longitude)
+			if lat < minLat {
+				minLat = lat
+			}
+			if lat > maxLat {
+				maxLat = lat
+			}
+			if lon < minLon {
+				minLon = lon
+			}
+			if lon > maxLon {
+				maxLon = lon
+			}
+		}
+	}
+
+	if minLat == math.MaxFloat64 || maxLat == -math.MaxFloat64 ||
+		minLon == math.MaxFloat64 || maxLon == -math.MaxFloat64 {
+		return BoundingBox{}, fmt.Errorf("no valid latitude/longitude found in stops")
+	}
+
+	return BoundingBox{
+		MinLat: minLat,
+		MaxLat: maxLat,
+		MinLon: minLon,
+		MaxLon: maxLon,
+	}, nil
+}
+
+// BoundingBoxStore stores bounding boxes for each server in memory with concurrency safety
+type BoundingBoxStore struct {
+	mu    sync.RWMutex
+	store map[int]BoundingBox
+}
+
+// NewBoundingBoxStore creates and returns a new BoundingBoxStore
+func NewBoundingBoxStore() *BoundingBoxStore {
+	return &BoundingBoxStore{
+		store: make(map[int]BoundingBox),
+	}
+}
+
+// Set stores a bounding box for a specific server ID
+func (s *BoundingBoxStore) Set(serverID int, bbox BoundingBox) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.store[serverID] = bbox
+}
+
+// Get retrieves the bounding box for a specific server ID
+func (s *BoundingBoxStore) Get(serverID int) (BoundingBox, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	bbox, ok := s.store[serverID]
+	return bbox, ok
+}
+
+// IsValidCoordinate checks if the given position is valid and inside the bounding box
+func (s *BoundingBoxStore) IsValidCoordinate(serverID int, lat, lon float64) bool {
+	if lat == 0 && lon == 0 {
+		return false
+	}
+	if lat < -90 || lat > 90 || lon < -180 || lon > 180 {
+		return false
+	}
+	bbox, ok := s.Get(serverID)
+	if !ok {
+		return false
+	}
+	return bbox.Contains(lat, lon)
+}

--- a/internal/geo/geo_utils.go
+++ b/internal/geo/geo_utils.go
@@ -92,7 +92,15 @@ func (s *BoundingBoxStore) Get(serverID int) (BoundingBox, bool) {
 	return bbox, ok
 }
 
-// IsValidLatLon checks for lat/lon validity (not nil, not 0/0, within global range)
+// IsValidLatLon returns true if the given latitude and longitude values
+// fall within the valid geographic coordinate bounds.
+//
+// Latitude must be between -90 and 90 degrees, and longitude must be
+// between -180 and 180 degrees.
+//
+// Note: This function treats the coordinate (0,0) as invalid, even though it
+// is a valid location in the Gulf of Guinea. This assumption is made to help
+// detect uninitialized or placeholder coordinates commonly represented as (0,0).
 func IsValidLatLon(lat, lon float64) bool {
 	if lat == 0 && lon == 0 {
 		return false

--- a/internal/geo/geo_utils.go
+++ b/internal/geo/geo_utils.go
@@ -92,14 +92,19 @@ func (s *BoundingBoxStore) Get(serverID int) (BoundingBox, bool) {
 	return bbox, ok
 }
 
-// IsValidCoordinate checks if the given position is valid and inside the bounding box
-func (s *BoundingBoxStore) IsValidCoordinate(serverID int, lat, lon float64) bool {
+// IsValidLatLon checks for lat/lon validity (not nil, not 0/0, within global range)
+func IsValidLatLon(lat, lon float64) bool {
 	if lat == 0 && lon == 0 {
 		return false
 	}
 	if lat < -90 || lat > 90 || lon < -180 || lon > 180 {
 		return false
 	}
+	return true
+}
+
+// IsInBoundingBox checks if the lat/lon is inside the server's bounding box
+func (s *BoundingBoxStore) IsInBoundingBox(serverID int, lat, lon float64) bool {
 	bbox, ok := s.Get(serverID)
 	if !ok {
 		return false

--- a/internal/gtfs/gtfs_bundles_test.go
+++ b/internal/gtfs/gtfs_bundles_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"watchdog.onebusaway.org/internal/geo"
 	"watchdog.onebusaway.org/internal/models"
 )
 
@@ -24,8 +25,9 @@ func TestDownloadGTFSBundles(t *testing.T) {
 
 	tempDir := t.TempDir()
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	store := geo.NewBoundingBoxStore()
 
-	DownloadGTFSBundles(servers, tempDir, logger)
+	DownloadGTFSBundles(servers, tempDir, logger, store)
 
 }
 
@@ -35,8 +37,9 @@ func TestRefreshGTFSBundles(t *testing.T) {
 
 	servers := []models.ObaServer{{ID: 1, Name: "Test Server", GtfsUrl: "http://example.com/gtfs.zip"}}
 	cacheDir := t.TempDir()
+	store := geo.NewBoundingBoxStore()
 
-	go RefreshGTFSBundles(servers, cacheDir, logger, 10*time.Millisecond)
+	go RefreshGTFSBundles(servers, cacheDir, logger, 10*time.Millisecond, store)
 
 	time.Sleep(15 * time.Millisecond)
 

--- a/internal/metrics/gtfs-realtime-bindings.go
+++ b/internal/metrics/gtfs-realtime-bindings.go
@@ -162,6 +162,20 @@ func TrackVehicleReportingFrequency(server models.ObaServer) error {
 	return nil
 }
 
+// VehicleStatusStoppedAtStop represents the GTFS-realtime vehicle stop status
+// where the vehicle is currently stopped at the stop.
+//
+// Possible values for VehicleStopStatus are:
+//   - 0 (INCOMING_AT): Vehicle is about to arrive at the stop
+//   - 1 (STOPPED_AT): Vehicle is standing at the stop (this constant)
+//   - 2 (IN_TRANSIT_TO): Vehicle has departed and is in transit to the next stop
+//
+// These values correspond to the VehicleStopStatus enum defined in the GTFS-realtime specification.
+//
+// For more details, see:
+// https://gtfs.org/documentation/realtime/reference/#enum-vehiclestopstatus
+const VehicleStatusStoppedAtStop = 1
+
 // TrackInvalidVehiclesAndStoppedOutOfBounds collects and reports metrics related to vehicle position validity.
 //
 // It performs two checks on each vehicle in the GTFS-RT feed:
@@ -219,7 +233,7 @@ func TrackInvalidVehiclesAndStoppedOutOfBounds(server models.ObaServer, store *g
 		}
 
 		// Check bounding box only if vehicle is stopped at the stop
-		if v.CurrentStatus != nil && *v.CurrentStatus == 1 {
+		if v.CurrentStatus != nil && *v.CurrentStatus == VehicleStatusStoppedAtStop {
 			if !boundingBox.Contains(lat, lon) {
 				outOfBoundsCount++
 			}

--- a/internal/metrics/gtfs-realtime-bindings.go
+++ b/internal/metrics/gtfs-realtime-bindings.go
@@ -196,8 +196,7 @@ func TrackInvalidVehiclesAndStoppedOutOfBounds(server models.ObaServer, store *g
 		return err
 	}
 
-	serverID := strconv.Itoa(server.ID)
-	_, ok := store.Get(server.ID)
+	boundingBox, ok := store.Get(server.ID)
 	if !ok {
 		return fmt.Errorf("no bounding box found for server ID %d", server.ID)
 	}
@@ -221,12 +220,13 @@ func TrackInvalidVehiclesAndStoppedOutOfBounds(server models.ObaServer, store *g
 
 		// Check bounding box only if vehicle is stopped at the stop
 		if v.CurrentStatus != nil && *v.CurrentStatus == 1 {
-			if !store.IsInBoundingBox(server.ID, lat, lon) {
+			if !boundingBox.Contains(lat, lon) {
 				outOfBoundsCount++
 			}
 		}
 	}
 
+	serverID := strconv.Itoa(server.ID)
 	InvalidVehicleCoordinatesGauge.WithLabelValues(serverID).Set(float64(invalidCount))
 	StoppedOutOfBoundsVehiclesGauge.WithLabelValues(serverID).Set(float64(outOfBoundsCount))
 

--- a/internal/metrics/gtfs-realtime-bindings_test.go
+++ b/internal/metrics/gtfs-realtime-bindings_test.go
@@ -176,7 +176,7 @@ func TestCheckVehicleCountMatch(t *testing.T) {
 	})
 }
 
-func TestTrackInvalidAndOutOfBoundsVehicles(t *testing.T) {
+func TestTrackInvalidVehiclesAndStoppedOutOfBounds(t *testing.T) {
 	store := geo.NewBoundingBoxStore()
 	store.Set(1, geo.BoundingBox{
 		MinLat: -90, MaxLat: 90,
@@ -194,7 +194,7 @@ func TestTrackInvalidAndOutOfBoundsVehicles(t *testing.T) {
 			GtfsRtApiValue:     "test-key",
 		}
 
-		err := TrackInvalidAndOutOfBoundsVehicles(server, store)
+		err := TrackInvalidVehiclesAndStoppedOutOfBounds(server, store)
 		if err != nil {
 			t.Errorf("Expected no error, got: %v", err)
 		}
@@ -206,7 +206,7 @@ func TestTrackInvalidAndOutOfBoundsVehicles(t *testing.T) {
 			VehiclePositionUrl: "http://invalid.localhost/test",
 		}
 
-		err := TrackInvalidAndOutOfBoundsVehicles(server, store)
+		err := TrackInvalidVehiclesAndStoppedOutOfBounds(server, store)
 		if err == nil {
 			t.Error("Expected error due to unreachable server, got nil")
 		}
@@ -223,7 +223,7 @@ func TestTrackInvalidAndOutOfBoundsVehicles(t *testing.T) {
 			GtfsRtApiValue:     "test-key",
 		}
 
-		err := TrackInvalidAndOutOfBoundsVehicles(server, store)
+		err := TrackInvalidVehiclesAndStoppedOutOfBounds(server, store)
 		if err == nil {
 			t.Error("Expected error due to missing bounding box, got nil")
 		}

--- a/internal/metrics/gtfs-realtime-bindings_test.go
+++ b/internal/metrics/gtfs-realtime-bindings_test.go
@@ -176,7 +176,7 @@ func TestCheckVehicleCountMatch(t *testing.T) {
 	})
 }
 
-func TestCountInvalidVehicleCoordinates(t *testing.T) {
+func TestTrackInvalidAndOutOfBoundsVehicles(t *testing.T) {
 	store := geo.NewBoundingBoxStore()
 	store.Set(1, geo.BoundingBox{
 		MinLat: -90, MaxLat: 90,
@@ -194,7 +194,7 @@ func TestCountInvalidVehicleCoordinates(t *testing.T) {
 			GtfsRtApiValue:     "test-key",
 		}
 
-		err := CountInvalidVehicleCoordinates(server, store)
+		err := TrackInvalidAndOutOfBoundsVehicles(server, store)
 		if err != nil {
 			t.Errorf("Expected no error, got: %v", err)
 		}
@@ -206,7 +206,7 @@ func TestCountInvalidVehicleCoordinates(t *testing.T) {
 			VehiclePositionUrl: "http://invalid.localhost/test",
 		}
 
-		err := CountInvalidVehicleCoordinates(server, store)
+		err := TrackInvalidAndOutOfBoundsVehicles(server, store)
 		if err == nil {
 			t.Error("Expected error due to unreachable server, got nil")
 		}
@@ -223,7 +223,7 @@ func TestCountInvalidVehicleCoordinates(t *testing.T) {
 			GtfsRtApiValue:     "test-key",
 		}
 
-		err := CountInvalidVehicleCoordinates(server, store)
+		err := TrackInvalidAndOutOfBoundsVehicles(server, store)
 		if err == nil {
 			t.Error("Expected error due to missing bounding box, got nil")
 		}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -79,10 +79,10 @@ var (
 		[]string{"server_id"},
 	)
 
-	OutOfBoundsVehicleCoordinatesGauge = promauto.NewGaugeVec(
+	StoppedOutOfBoundsVehiclesGauge = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "gtfs_rt_out_of_bounds_vehicle_coordinates",
-			Help: "Current number of GTFS-RT vehicle positions outside bounding box",
+			Name: "gtfs_rt_stopped_out_of_bounds_vehicles",
+			Help: "Number of vehicles outside bounding box while stopped at a stop",
 		},
 		[]string{"server_id"},
 	)

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -70,6 +70,14 @@ var (
 		Name: "vehicle_report_total",
 		Help: "Total number of GTFS-RT updates received from each vehicle",
 	}, []string{"vehicle_id", "server_id"})
+
+	InvalidVehicleCoordinates = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "gtfs_rt_invalid_vehicle_coordinates_total",
+			Help: "Total number of GTFS-RT vehicle position records with invalid coordinates (lat/lon or out-of-bounds)",
+		},
+		[]string{"server_id"},
+	)
 )
 
 // OBA REST API 2.6.0 >= Metrics

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -71,10 +71,18 @@ var (
 		Help: "Total number of GTFS-RT updates received from each vehicle",
 	}, []string{"vehicle_id", "server_id"})
 
-	InvalidVehicleCoordinates = promauto.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "gtfs_rt_invalid_vehicle_coordinates_total",
-			Help: "Total number of GTFS-RT vehicle position records with invalid coordinates (lat/lon or out-of-bounds)",
+	InvalidVehicleCoordinatesGauge = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "gtfs_rt_invalid_vehicle_coordinates",
+			Help: "Current number of GTFS-RT vehicle positions with invalid coordinates",
+		},
+		[]string{"server_id"},
+	)
+
+	OutOfBoundsVehicleCoordinatesGauge = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "gtfs_rt_out_of_bounds_vehicle_coordinates",
+			Help: "Current number of GTFS-RT vehicle positions outside bounding box",
 		},
 		[]string{"server_id"},
 	)


### PR DESCRIPTION
This PR introduces logic to compute and use bounding boxes from GTFS static data to validate GTFS-RT vehicle positions. It enhances the accuracy and observability of vehicle feeds by flagging invalid or out-of-bounds coordinates.

---

###  Features

* Compute bounding box per GTFS static feed 
* Store bounding boxes per server in memory 
* Add `IsValidCoordinate` method to validate lat/lon against bounding box
* Report invalid GTFS-RT coordinates as a Prometheus counter (`gtfs_rt_invalid_vehicle_coordinates_total`)

###  Refactors

* Refactor `CountInvalidVehicleCoordinates` to use injected `BoundingBoxStore`
* Inject `BoundingBoxStore` into the `Application` struct for centralized access
* Update `DownloadGTFSBundles` to compute and cache bounding boxes after parsing

###  Tests

* Add unit tests for valid and invalid GTFS-RT coordinates
* Cover edge cases: missing bounding box, nil positions, out-of-range coordinates

