### PR TITLE
feat: Add vehicle telemetry tracking with computed speed and discrepancy metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.23.5
 require (
 	github.com/OneBusAway/go-sdk v0.1.0-alpha.13
 	github.com/getsentry/sentry-go v0.33.0
-	github.com/golang/geo v0.0.0-20250630213057-fac2d31592dd
+	github.com/golang/geo v0.0.0-20250707181242-c5087ca84cf4
 	github.com/jamespfennell/gtfs v0.1.24
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/prometheus/client_golang v1.20.5

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,8 @@ github.com/getsentry/sentry-go v0.33.0 h1:YWyDii0KGVov3xOaamOnF0mjOrqSjBqwv48UEz
 github.com/getsentry/sentry-go v0.33.0/go.mod h1:C55omcY9ChRQIUcVcGcs+Zdy4ZpQGvNJ7JYHIoSWOtE=
 github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=
 github.com/go-errors/errors v1.4.2/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=
-github.com/golang/geo v0.0.0-20250630213057-fac2d31592dd h1:4BU/Fy2KwDucgY0al91L0wJI05rb1Y4hQKucQkybjT8=
-github.com/golang/geo v0.0.0-20250630213057-fac2d31592dd/go.mod h1:Vaw7L5b+xa3Rj4/pRtrQkymn3lSBRB/NAEdbF9YEVLA=
+github.com/golang/geo v0.0.0-20250707181242-c5087ca84cf4 h1:vCeHcs8N7MOccOOsOVIy1xcYu+kBkA4J5urTgigww7c=
+github.com/golang/geo v0.0.0-20250707181242-c5087ca84cf4/go.mod h1:AN0OjM34c3PbjAsX+QNma1nYtJtRxl+s9MZNV7S+efw=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/jamespfennell/gtfs v0.1.24 h1:em/W8Bg88xZwX70r7FoghMiuZDn3m5oj0EfqmikU1Io=

--- a/internal/app/metrics_collector.go
+++ b/internal/app/metrics_collector.go
@@ -105,7 +105,7 @@ func (app *Application) CollectMetricsForServer(server models.ObaServer) {
 			Level: sentry.LevelError,
 		})
 	}
-	err = metrics.TrackVehicleReportingFrequency(server)
+	err = metrics.TrackVehicleTelemetry(server)
 	if err != nil {
 		app.Logger.Error("Failed to track vehicle reporting frequency", "error", err)
 		report.ReportErrorWithSentryOptions(err, report.SentryReportOptions{

--- a/internal/geo/geo_utils.go
+++ b/internal/geo/geo_utils.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"sync"
 
+	"github.com/golang/geo/s2"
 	"github.com/jamespfennell/gtfs"
 )
 
@@ -118,4 +119,12 @@ func (s *BoundingBoxStore) IsInBoundingBox(serverID int, lat, lon float64) bool 
 		return false
 	}
 	return bbox.Contains(lat, lon)
+}
+
+const earthRadiusMeters = 6371000
+
+func HaversineDistance(lat1, lon1, lat2, lon2 float64) float64 {
+	p1 := s2.LatLngFromDegrees(lat1, lon1)
+	p2 := s2.LatLngFromDegrees(lat2, lon2)
+	return p1.Distance(p2).Radians() * earthRadiusMeters
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -71,6 +71,22 @@ var (
 		Help: "Total number of GTFS-RT updates received from each vehicle",
 	}, []string{"vehicle_id", "server_id"})
 
+	VehicleSpeedGauge = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "gtfs_rt_vehicle_computed_speed",
+			Help: "Computed speed of the vehicle in m/s based on GTFS-RT positions and timestamps",
+		},
+		[]string{"vehicle_id", "agency_id", "server_id"},
+	)
+
+	VehicleSpeedDiscrepancyRatioGauge = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "gtfs_rt_vehicle_speed_discrepancy_ratio",
+			Help: "Ratio between computed and reported speed (|computed - reported| / reported)",
+		},
+		[]string{"vehicle_id", "agency_id", "server_id"},
+	)
+
 	InvalidVehicleCoordinatesGauge = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "gtfs_rt_invalid_vehicle_coordinates",


### PR DESCRIPTION
* Renamed `TrackVehicleReportingFrequency` → `TrackVehicleTelemetry` to reflect expanded functionality.
* Introduced `LastSeen` struct to store vehicle timestamp and coordinates.
* Calculated speed using Haversine distance between consecutive GTFS-RT reports.
* Added Prometheus gauge: `gtfs_rt_vehicle_computed_speed`.
* Added Prometheus gauge: `gtfs_rt_vehicle_speed_discrepancy_ratio` to detect anomalies.
