### PR TITLE
Encapsulate Config Access with Internal Locking and Thread-Safe Getters

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/golang/geo v0.0.0-20250707181242-c5087ca84cf4
 	github.com/klauspost/compress v1.17.11 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/golang/geo v0.0.0-20250707181242-c5087ca84cf4
 	github.com/klauspost/compress v1.17.11 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,10 @@ github.com/golang/geo v0.0.0-20250707181242-c5087ca84cf4 h1:vCeHcs8N7MOccOOsOVIy
 github.com/golang/geo v0.0.0-20250707181242-c5087ca84cf4/go.mod h1:AN0OjM34c3PbjAsX+QNma1nYtJtRxl+s9MZNV7S+efw=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/golang/geo v0.0.0-20250707181242-c5087ca84cf4 h1:vCeHcs8N7MOccOOsOVIy1xcYu+kBkA4J5urTgigww7c=
+github.com/golang/geo v0.0.0-20250707181242-c5087ca84cf4/go.mod h1:AN0OjM34c3PbjAsX+QNma1nYtJtRxl+s9MZNV7S+efw=
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/jamespfennell/gtfs v0.1.24 h1:em/W8Bg88xZwX70r7FoghMiuZDn3m5oj0EfqmikU1Io=
 github.com/jamespfennell/gtfs v0.1.24/go.mod h1:nj9QFIc695IUKM5djZXzyPtCIAYxufafb0sQNbiVMOs=
 github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4dN7jwJOQ1U=

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -2,10 +2,8 @@ package app
 
 import (
 	"log/slog"
-	"sync"
 
 	"watchdog.onebusaway.org/internal/geo"
-	"watchdog.onebusaway.org/internal/models"
 	"watchdog.onebusaway.org/internal/server"
 )
 
@@ -21,14 +19,6 @@ import (
 type Application struct {
 	Config           server.Config
 	Logger           *slog.Logger
-	Mu               sync.RWMutex
 	Version          string
 	BoundingBoxStore *geo.BoundingBoxStore
-}
-
-// updateConfig safely updates the application's server configuration.
-func (app *Application) UpdateConfig(newServers []models.ObaServer) {
-	app.Mu.Lock()
-	defer app.Mu.Unlock()
-	app.Config.Servers = newServers
 }

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -18,12 +18,12 @@ func TestUpdateConfig(t *testing.T) {
 		{ID: 2, Name: "Server 2"},
 	}
 
-	app.UpdateConfig(initialServers)
+	app.Config.UpdateConfig(initialServers)
 	if len(app.Config.Servers) != 1 {
 		t.Errorf("Expected 1 server, got %d", len(app.Config.Servers))
 	}
 
-	app.UpdateConfig(newServers)
+	app.Config.UpdateConfig(newServers)
 	if len(app.Config.Servers) != 2 {
 		t.Errorf("Expected 2 servers, got %d", len(app.Config.Servers))
 	}

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -19,12 +19,12 @@ func TestUpdateConfig(t *testing.T) {
 	}
 
 	app.Config.UpdateConfig(initialServers)
-	if len(app.Config.Servers) != 1 {
+	if len(app.Config.GetServers()) != 1 {
 		t.Errorf("Expected 1 server, got %d", len(app.Config.Servers))
 	}
 
 	app.Config.UpdateConfig(newServers)
-	if len(app.Config.Servers) != 2 {
+	if len(app.Config.GetServers()) != 2 {
 		t.Errorf("Expected 2 servers, got %d", len(app.Config.Servers))
 	}
 

--- a/internal/app/handlers.go
+++ b/internal/app/handlers.go
@@ -22,9 +22,7 @@ type HealthStatus struct {
 // with HTTP 500 Internal Server Error; otherwise, it responds with HTTP 200 OK.
 
 func (app *Application) healthcheckHandler(w http.ResponseWriter, r *http.Request) {
-	app.Mu.RLock()
-	numServers := len(app.Config.Servers)
-	app.Mu.RUnlock()
+	numServers := len(app.Config.GetServers())
 
 	ready := numServers > 0 // Consider ready if at least one server is configured
 

--- a/internal/app/metrics_collector.go
+++ b/internal/app/metrics_collector.go
@@ -19,9 +19,7 @@ func (app *Application) StartMetricsCollection() {
 			select {
 			case <-ticker.C:
 
-				app.Mu.Lock()
-				servers := app.Config.Servers
-				app.Mu.Unlock()
+				servers := app.Config.GetServers()
 
 				for _, server := range servers {
 					app.CollectMetricsForServer(server)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -39,7 +39,7 @@ func RefreshConfig(configURL, configAuthUser, configAuthPass string, app *app.Ap
 			continue
 		}
 
-		app.UpdateConfig(newServers)
+		app.Config.UpdateConfig(newServers)
 		logger.Info("Successfully refreshed server configuration")
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -303,9 +303,7 @@ func TestRefreshConfig(t *testing.T) {
 		t.Fatal("Mock server was never called")
 	}
 
-	app.Mu.RLock()
-	updatedServers := app.Config.Servers
-	app.Mu.RUnlock()
+	updatedServers := app.Config.GetServers()
 
 	if len(updatedServers) == 0 {
 		t.Fatal("No servers found in updated configuration")

--- a/internal/geo/geo_utils.go
+++ b/internal/geo/geo_utils.go
@@ -121,10 +121,18 @@ func (s *BoundingBoxStore) IsInBoundingBox(serverID int, lat, lon float64) bool 
 	return bbox.Contains(lat, lon)
 }
 
-const earthRadiusMeters = 6371000
+// earthRadiusInMeters represents the mean radius of the Earth in meters.
+//
+// This value (6,371,000 meters) is defined as the Earth's volumetric mean radius,
+// which is commonly used for general geospatial calculations and spherical approximations.
+//
+// Reference: NASA Planetary Fact Sheet – Earth
+// https://nssdc.gsfc.nasa.gov/planetary/factsheet/earthfact.html
+const earthRadiusInMeters = 6371000
+
 
 func HaversineDistance(lat1, lon1, lat2, lon2 float64) float64 {
 	p1 := s2.LatLngFromDegrees(lat1, lon1)
 	p2 := s2.LatLngFromDegrees(lat2, lon2)
-	return p1.Distance(p2).Radians() * earthRadiusMeters
+	return p1.Distance(p2).Radians() * earthRadiusInMeters
 }

--- a/internal/gtfs/gtfs_bundles.go
+++ b/internal/gtfs/gtfs_bundles.go
@@ -48,12 +48,14 @@ func DownloadGTFSBundles(servers []models.ObaServer, cacheDir string, logger *sl
 			continue
 		}
 
+		// compute bounding box for each downloaded GTFS bundle
 		bbox, err := geo.ComputeBoundingBox(staticData.Stops)
 		if err != nil {
 			logger.Warn("Could not compute bounding box", "server_id", server.ID, "error", err)
 			continue
 		}
 
+		// one bounding box per server
 		store.Set(server.ID, bbox)
 		logger.Info("Computed bounding box", "server_id", server.ID, "bbox", bbox)
 	}

--- a/internal/metrics/gtfs-realtime-bindings.go
+++ b/internal/metrics/gtfs-realtime-bindings.go
@@ -116,7 +116,6 @@ type LastSeen struct {
 	Lon  float64
 }
 
-
 // vehicleLastSeen stores the most recent known location and timestamp for each vehicle per server.
 //
 // The outer map key is the server ID (int), and the inner map key is the vehicle ID (string).
@@ -131,14 +130,14 @@ var vehicleLastSeen = make(map[int]map[string]LastSeen)
 // TrackVehicleTelemetry collects and reports various telemetry metrics for vehicles in a GTFS-RT feed.
 //
 // This function performs the following tasks:
-//   1. Fetches and parses the GTFS-RT vehicle positions feed for the given OBA server.
-//   2. For each valid vehicle entry:
-//      - Tracks the number of GTFS-RT updates received (`vehicle_report_total`).
-//      - Measures the interval since the last report (`vehicle_position_report_interval_seconds`).
-//      - Computes the vehicle speed based on current and previous coordinates and timestamps.
-//      - Reports the computed speed to Prometheus (`gtfs_rt_vehicle_computed_speed`).
-//      - Compares the computed speed with the reported speed (if available) and reports the relative discrepancy
-//        (`gtfs_rt_vehicle_speed_discrepancy_ratio`).
+//  1. Fetches and parses the GTFS-RT vehicle positions feed for the given OBA server.
+//  2. For each valid vehicle entry:
+//     - Tracks the number of GTFS-RT updates received (`vehicle_report_total`).
+//     - Measures the interval since the last report (`vehicle_position_report_interval_seconds`).
+//     - Computes the vehicle speed based on current and previous coordinates and timestamps.
+//     - Reports the computed speed to Prometheus (`gtfs_rt_vehicle_computed_speed`).
+//     - Compares the computed speed with the reported speed (if available) and reports the relative discrepancy
+//     (`gtfs_rt_vehicle_speed_discrepancy_ratio`).
 //
 // All metrics are labeled by `vehicle_id`, `server_id`, and `agency_id` to support detailed monitoring and alerting.
 //

--- a/internal/metrics/gtfs-realtime-bindings.go
+++ b/internal/metrics/gtfs-realtime-bindings.go
@@ -207,7 +207,7 @@ func TrackVehicleTelemetry(server models.ObaServer) error {
 
 				VehicleSpeedGauge.WithLabelValues(vehicleID, agencyID, strconv.Itoa(serverID)).Set(computedSpeed)
 
-				// Compare with reported speed with computed speed
+				// Compare reported speed with computed speed
 				if vehicle.Position.Speed != nil {
 					reportedSpeed := float64(*vehicle.Position.Speed)
 					if reportedSpeed > 0 {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -34,10 +34,8 @@ func (cfg *Config) UpdateConfig(newServers []models.ObaServer) {
 // concurrent modification issues.
 // This method should be used to access the servers from other parts of the application.
 // It returns a copy of the servers slice to ensure thread safety.
-// Callers should not modify the returned slice.
-// If you need to modify the servers, use UpdateConfig instead.
 func (cfg *Config) GetServers() []models.ObaServer{
 	cfg.Mu.RLock()
 	defer cfg.Mu.RUnlock()
-	return cfg.Servers
+	return append([]models.ObaServer(nil), cfg.Servers...)
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -10,7 +10,7 @@ import (
 type Config struct {
 	Port    int
 	Env     string
-	Mu    sync.RWMutex
+	Mu      sync.RWMutex
 	Servers []models.ObaServer
 }
 
@@ -34,7 +34,7 @@ func (cfg *Config) UpdateConfig(newServers []models.ObaServer) {
 // concurrent modification issues.
 // This method should be used to access the servers from other parts of the application.
 // It returns a copy of the servers slice to ensure thread safety.
-func (cfg *Config) GetServers() []models.ObaServer{
+func (cfg *Config) GetServers() []models.ObaServer {
 	cfg.Mu.RLock()
 	defer cfg.Mu.RUnlock()
 	return append([]models.ObaServer(nil), cfg.Servers...)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,11 +1,16 @@
 package server
 
-import "watchdog.onebusaway.org/internal/models"
+import (
+	"sync"
+
+	"watchdog.onebusaway.org/internal/models"
+)
 
 // Config Holds all the configuration settings for our application
 type Config struct {
 	Port    int
 	Env     string
+	Mu    sync.RWMutex
 	Servers []models.ObaServer
 }
 
@@ -16,4 +21,23 @@ func NewConfig(port int, env string, servers []models.ObaServer) *Config {
 		Env:     env,
 		Servers: servers,
 	}
+}
+
+// updateConfig safely updates the config servers.
+func (cfg *Config) UpdateConfig(newServers []models.ObaServer) {
+	cfg.Mu.Lock()
+	defer cfg.Mu.Unlock()
+	cfg.Servers = newServers
+}
+
+// GetServers safely returns a copy of the servers slice to avoid
+// concurrent modification issues.
+// This method should be used to access the servers from other parts of the application.
+// It returns a copy of the servers slice to ensure thread safety.
+// Callers should not modify the returned slice.
+// If you need to modify the servers, use UpdateConfig instead.
+func (cfg *Config) GetServers() []models.ObaServer{
+	cfg.Mu.RLock()
+	defer cfg.Mu.RUnlock()
+	return cfg.Servers
 }


### PR DESCRIPTION
* Moved `UpdateConfig` and `sync.RWMutex` from `Application` to `Config` for better encapsulation
* Added `GetServers()` method with read-lock for safe concurrent access
* Replaced all direct access to `Config.Servers` with `GetServers()` or `UpdateConfig()`
* Updated `GetServers()` to return a copy to prevent shared mutation and ensure thread safety
