### PR TITLE
perf: add exponential backoff for retries and HTTP requests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/prometheus/client_golang v1.20.5
 	github.com/prometheus/client_model v0.6.1
+	github.com/prometheus/common v0.62.0
 	gopkg.in/dnaeon/go-vcr.v4 v4.0.2
 )
 
@@ -19,7 +20,6 @@ require (
 	github.com/klauspost/compress v1.17.11 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/prometheus/common v0.62.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/tidwall/gjson v1.18.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -31,8 +31,9 @@ func New(cfg *config.Config, logger *slog.Logger, client *http.Client, version s
 	realtimeStore := gtfs.NewRealtimeStore()
 	boundingBoxStore := geo.NewBoundingBoxStore()
 	vehicleLastSeen := metrics.NewVehicleLastSeen()
+	backoffStore := config.NewBackoffStore()
 
-	configService := config.NewConfigService(logger, client, cfg)
+	configService := config.NewConfigService(logger, client, cfg,backoffStore)
 	gtfsService := gtfs.NewGtfsService(staticStore, realtimeStore, boundingBoxStore, logger, client)
 	metricsService := metrics.NewMetricsService(staticStore, realtimeStore, boundingBoxStore, vehicleLastSeen, logger, client)
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -33,7 +33,7 @@ func New(cfg *config.Config, logger *slog.Logger, client *http.Client, version s
 	vehicleLastSeen := metrics.NewVehicleLastSeen()
 	backoffStore := config.NewBackoffStore()
 
-	configService := config.NewConfigService(logger, client, cfg,backoffStore)
+	configService := config.NewConfigService(logger, client, cfg, backoffStore)
 	gtfsService := gtfs.NewGtfsService(staticStore, realtimeStore, boundingBoxStore, logger, client)
 	metricsService := metrics.NewMetricsService(staticStore, realtimeStore, boundingBoxStore, vehicleLastSeen, logger, client)
 

--- a/internal/app/handlers_test.go
+++ b/internal/app/handlers_test.go
@@ -65,8 +65,9 @@ func TestHealthcheckHandler(t *testing.T) {
 		)
 		logger := slog.Default()
 		client := http.Client{}
+		backoffStore := config.NewBackoffStore()
 		app := &Application{
-			ConfigService: config.NewConfigService(logger, &client, cfg),
+			ConfigService: config.NewConfigService(logger, &client, cfg,backoffStore),
 			Version:       "test-version",
 		}
 

--- a/internal/app/handlers_test.go
+++ b/internal/app/handlers_test.go
@@ -67,7 +67,7 @@ func TestHealthcheckHandler(t *testing.T) {
 		client := http.Client{}
 		backoffStore := config.NewBackoffStore()
 		app := &Application{
-			ConfigService: config.NewConfigService(logger, &client, cfg,backoffStore),
+			ConfigService: config.NewConfigService(logger, &client, cfg, backoffStore),
 			Version:       "test-version",
 		}
 

--- a/internal/app/test_helpers.go
+++ b/internal/app/test_helpers.go
@@ -87,9 +87,9 @@ func newTestApplication(t *testing.T) *Application {
 	realtimeStore.Set(realtimeData)
 
 	vehicleLastSeen := metrics.NewVehicleLastSeen()
-
+	backoffStore := config.NewBackoffStore()
 	return &Application{
-		ConfigService:  config.NewConfigService(logger, client, cfg),
+		ConfigService:  config.NewConfigService(logger, client, cfg, backoffStore),
 		GtfsService:    gtfs.NewGtfsService(staticStore, realtimeStore, boundingBoxStore, logger, client),
 		MetricsService: metrics.NewMetricsService(staticStore, realtimeStore, boundingBoxStore, vehicleLastSeen, logger, client),
 		Version:        "1.0.0",

--- a/internal/config/backoff_time_store.go
+++ b/internal/config/backoff_time_store.go
@@ -1,0 +1,80 @@
+package config
+
+import (
+	"math/rand/v2"
+	"sync"
+	"time"
+)
+
+const (
+	BASE_BACKOFF   = 1 * time.Second
+	MAX_BACKOFF    = 2 * time.Minute
+	BACKOFF_FACTOR = 2.0
+	JITTER_FACTOR  = 0.5
+)
+
+type backoffData struct {
+	BackoffDelay time.Duration
+	NextRetryAt  time.Time
+}
+
+type BackoffStore struct {
+	mu       sync.RWMutex
+	backoffs map[int]backoffData
+}
+
+func NewBackoffStore() *BackoffStore {
+	return &BackoffStore{
+		backoffs: make(map[int]backoffData),
+	}
+}
+
+func (s *BackoffStore) NextRetryAt(serverID int) (time.Time, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if backoff, exists := s.backoffs[serverID]; exists {
+		return backoff.NextRetryAt.UTC(), true
+	}
+	return time.Time{}, false
+}
+
+func (s *BackoffStore) UpdateBackoff(serverID int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if backoff, exists := s.backoffs[serverID]; exists {
+		backoff.BackoffDelay = calculateNewBackoffDelay(backoff.BackoffDelay)
+		backoff.NextRetryAt = calculateNextRetryAt(backoff.BackoffDelay)
+		s.backoffs[serverID] = backoff
+	} else {
+		s.backoffs[serverID] = backoffData{
+			BackoffDelay: BASE_BACKOFF,
+			NextRetryAt:  calculateNextRetryAt(BASE_BACKOFF),
+		}
+	}
+}
+
+func (s *BackoffStore) ResetBackoff(serverID int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	delete(s.backoffs, serverID)
+}
+
+
+func calculateNextRetryAt(backoff time.Duration) time.Time {
+	jitter := time.Duration(rand.Float64() * float64(backoff) * JITTER_FACTOR)
+	backoff += jitter
+	if backoff > MAX_BACKOFF {
+		backoff = MAX_BACKOFF
+	}
+	return time.Now().Add(backoff).UTC()
+}
+
+func calculateNewBackoffDelay(backoffDelay time.Duration) time.Duration {
+	backoffDelay *= BACKOFF_FACTOR
+	if backoffDelay >= MAX_BACKOFF {
+		backoffDelay = MAX_BACKOFF
+	}
+	return backoffDelay
+}

--- a/internal/config/backoff_time_store_test.go
+++ b/internal/config/backoff_time_store_test.go
@@ -1,0 +1,85 @@
+package config
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDoWithBackoff(t *testing.T) {
+	tests := []struct {
+		name          string
+		maxRetries    int
+		ctxTimeout    time.Duration
+		handler       func(req *http.Request) (*http.Response, error)
+		expectErr     string
+		expectCalls   int
+		expectSuccess bool
+	}{
+		{
+			name:       "success on first try",
+			maxRetries: 3,
+			handler: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{StatusCode: 200, Body: http.NoBody}, nil
+			},
+			expectErr:     "",
+			expectCalls:   1,
+			expectSuccess: true,
+		},
+		{
+			name:       "max retries exceeded",
+			maxRetries: 2,
+			handler: func(req *http.Request) (*http.Response, error) {
+				return nil, errors.New("mock error")
+			},
+			expectErr:   "max retries exceeded",
+			expectCalls: 3,
+		},
+		{
+			name:       "context cancelled before success",
+			maxRetries: 0,
+			ctxTimeout: 50 * time.Millisecond,
+			handler: func(req *http.Request) (*http.Response, error) {
+				return nil, errors.New("fail")
+			},
+			expectErr:   "context deadline exceeded",
+			expectCalls: -1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockRoundTripper{handler: tt.handler}
+			client := &http.Client{Transport: mock}
+			req, _ := http.NewRequest("GET", "http://example.com", nil)
+
+			ctx := context.Background()
+			if tt.ctxTimeout > 0 {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithTimeout(ctx, tt.ctxTimeout)
+				defer cancel()
+			}
+
+			resp, err := DoWithBackoff(ctx, client, req, tt.maxRetries)
+
+			if tt.expectErr == "" && err != nil {
+				t.Fatalf("expected success, got error: %v", err)
+			}
+			if tt.expectErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.expectErr) {
+					t.Fatalf("expected error containing %q, got %v", tt.expectErr, err)
+				}
+			}
+			if tt.expectSuccess && resp == nil {
+				t.Fatalf("expected response, got nil")
+			}
+
+			if tt.expectCalls >= 0 && mock.calls != tt.expectCalls {
+				t.Errorf("expected %d calls, got %d", tt.expectCalls, mock.calls)
+			}
+		})
+	}
+}

--- a/internal/config/config_loader.go
+++ b/internal/config/config_loader.go
@@ -55,7 +55,7 @@ func refreshConfig(ctx context.Context, client *http.Client, configURL, configAu
 					Level: sentry.LevelError,
 				})
 				logger.Error("Failed to refresh remote config", "error", err)
-			}else {
+			} else {
 				cfg.UpdateConfig(newServers)
 				logger.Info("Successfully refreshed server configuration")
 			}

--- a/internal/config/config_loader.go
+++ b/internal/config/config_loader.go
@@ -41,27 +41,25 @@ func ValidateConfigFlags(configFile, configURL *string) error {
 // ensuring resiliency in the presence of transient issues.
 //
 // The routine stops gracefully when the context is canceled.
-func refreshConfig(ctx context.Context, client *http.Client, configURL, configAuthUser, configAuthPass string, cfg *Config, logger *slog.Logger, interval time.Duration) {
-	ticker := time.NewTicker(interval)
-	defer ticker.Stop()
+func refreshConfig(ctx context.Context, client *http.Client, configURL, configAuthUser, configAuthPass string, cfg *Config, logger *slog.Logger, interval time.Duration, maxRetries int) {
 	for {
 		select {
 		case <-ctx.Done():
 			logger.Info("Stopping config refresh routine")
 			return
-		case <-ticker.C:
-			newServers, err := loadConfigFromURL(client, configURL, configAuthUser, configAuthPass)
+		default:
+			newServers, err := loadConfigFromURL(ctx, client, configURL, configAuthUser, configAuthPass, maxRetries)
 			if err != nil {
 				report.ReportErrorWithSentryOptions(err, report.SentryReportOptions{
 					Tags:  utils.MakeMap("config_url", configURL),
 					Level: sentry.LevelError,
 				})
 				logger.Error("Failed to refresh remote config", "error", err)
-				continue
+			}else {
+				cfg.UpdateConfig(newServers)
+				logger.Info("Successfully refreshed server configuration")
 			}
-
-			cfg.UpdateConfig(newServers)
-			logger.Info("Successfully refreshed server configuration")
+			time.Sleep(interval)
 		}
 	}
 }
@@ -102,7 +100,7 @@ func loadConfigFromFile(filePath string) ([]models.ObaServer, error) {
 // into a slice of `models.ObaServer`.
 //
 // Errors are logged and reported to Sentry for observability.
-func loadConfigFromURL(client *http.Client, url, authUser, authPass string) ([]models.ObaServer, error) {
+func loadConfigFromURL(ctx context.Context, client *http.Client, url, authUser, authPass string, maxRetries int) ([]models.ObaServer, error) {
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		report.ReportErrorWithSentryOptions(err, report.SentryReportOptions{
@@ -116,7 +114,7 @@ func loadConfigFromURL(client *http.Client, url, authUser, authPass string) ([]m
 		req.SetBasicAuth(authUser, authPass)
 	}
 
-	resp, err := client.Do(req)
+	resp, err := DoWithBackoff(ctx, client, req, maxRetries)
 	if err != nil {
 		report.ReportErrorWithSentryOptions(err, report.SentryReportOptions{
 			Tags:  utils.MakeMap("config_url", url),
@@ -124,6 +122,7 @@ func loadConfigFromURL(client *http.Client, url, authUser, authPass string) ([]m
 		})
 		return nil, fmt.Errorf("failed to fetch remote config: %v", err)
 	}
+
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {

--- a/internal/config/config_loader_test.go
+++ b/internal/config/config_loader_test.go
@@ -97,6 +97,7 @@ func TestLoadConfigFromURL(t *testing.T) {
 	client := &http.Client{
 		Timeout: 10 * time.Second,
 	}
+	ctx := context.Background()
 	t.Run("ValidResponse", func(t *testing.T) {
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
@@ -113,7 +114,7 @@ func TestLoadConfigFromURL(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		servers, err := loadConfigFromURL(client, ts.URL, "user", "pass")
+		servers, err := loadConfigFromURL(ctx, client, ts.URL, "user", "pass", 1)
 		if err != nil {
 			t.Fatalf("loadConfigFromURL failed: %v", err)
 		}
@@ -143,7 +144,7 @@ func TestLoadConfigFromURL(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		_, err := loadConfigFromURL(client, ts.URL, "", "")
+		_, err := loadConfigFromURL(ctx, client, ts.URL, "", "", 1)
 		if err == nil {
 			t.Errorf("Expected error with 500 response, got none")
 		}
@@ -156,13 +157,13 @@ func TestLoadConfigFromURL(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		_, err := loadConfigFromURL(client, ts.URL, "", "")
+		_, err := loadConfigFromURL(ctx, client, ts.URL, "", "", 1)
 		if err == nil {
 			t.Errorf("Expected error for invalid JSON response, got none")
 		}
 	})
 	t.Run("InvalidURL", func(t *testing.T) {
-		_, err := loadConfigFromURL(client, "://invalid-url", "", "")
+		_, err := loadConfigFromURL(ctx, client, "://invalid-url", "", "", 1)
 		if err == nil || !strings.Contains(err.Error(), "failed to create request") {
 			t.Errorf("Expected request creation error, got: %v", err)
 		}
@@ -329,7 +330,7 @@ func TestRefreshConfig(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	go refreshConfig(ctx, client, mockServer.URL, "testuser", "testpass", cfg, testLogger, 100*time.Millisecond)
+	go refreshConfig(ctx, client, mockServer.URL, "testuser", "testpass", cfg, testLogger, 100*time.Millisecond, 1)
 
 	time.Sleep(200 * time.Millisecond)
 

--- a/internal/config/config_service.go
+++ b/internal/config/config_service.go
@@ -15,17 +15,19 @@ import (
 
 // ConfigService holds dependencies and provides config operations.
 type ConfigService struct {
-	Logger *slog.Logger
-	Client *http.Client
-	Config *Config
+	Logger       *slog.Logger
+	Client       *http.Client
+	Config       *Config
+	BackoffStore *BackoffStore
 }
 
 // NewConfigService creates a new ConfigService instance with the provided logger and HTTP client.
-func NewConfigService(logger *slog.Logger, client *http.Client, config *Config) *ConfigService {
+func NewConfigService(logger *slog.Logger, client *http.Client, config *Config, backoffStore *BackoffStore) *ConfigService {
 	return &ConfigService{
-		Logger: logger,
-		Client: client,
-		Config: config,
+		Logger:       logger,
+		Client:       client,
+		Config:       config,
+		BackoffStore: backoffStore,
 	}
 }
 

--- a/internal/config/config_service.go
+++ b/internal/config/config_service.go
@@ -31,8 +31,8 @@ func NewConfigService(logger *slog.Logger, client *http.Client, config *Config, 
 	}
 }
 
-func (cs *ConfigService) RefreshConfig(ctx context.Context, url, authUser, authPass string, interval time.Duration) {
-	refreshConfig(ctx, cs.Client, url, authUser, authPass, cs.Config, cs.Logger, interval)
+func (cs *ConfigService) RefreshConfig(ctx context.Context, url, authUser, authPass string, interval time.Duration, maxRetries int) {
+	refreshConfig(ctx, cs.Client, url, authUser, authPass, cs.Config, cs.Logger, interval, maxRetries)
 }
 
 // exported helper functions
@@ -52,8 +52,8 @@ func LoadConfigFromFile(filePath string) ([]models.ObaServer, error) {
 }
 
 // Load config from URL and update Config.
-func LoadConfigFromURL(client *http.Client, url, authUser, authPass string) ([]models.ObaServer, error) {
-	servers, err := loadConfigFromURL(client, url, authUser, authPass)
+func LoadConfigFromURL(ctx context.Context, client *http.Client, url, authUser, authPass string, maxRetires int) ([]models.ObaServer, error) {
+	servers, err := loadConfigFromURL(ctx, client, url, authUser, authPass, maxRetires)
 	if err != nil {
 		err := fmt.Errorf("failed to load config from URL %s: %w", url, err)
 		report.ReportErrorWithSentryOptions(err, report.SentryReportOptions{

--- a/internal/config/test_helpers.go
+++ b/internal/config/test_helpers.go
@@ -1,0 +1,13 @@
+package config
+
+import "net/http"
+
+type mockRoundTripper struct {
+	calls   int
+	handler func(req *http.Request) (*http.Response, error)
+}
+
+func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	m.calls++
+	return m.handler(req)
+}

--- a/internal/gtfs/gtfs_service.go
+++ b/internal/gtfs/gtfs_service.go
@@ -29,8 +29,8 @@ func NewGtfsService(staticStore *StaticStore, realtimeStore *RealtimeStore, boun
 	}
 }
 
-func (gs *GtfsService) DownloadGTFSBundles(servers []models.ObaServer) {
-	downloadGTFSBundles(servers, gs.Logger, gs.BoundingBoxStore, gs.StaticStore)
+func (gs *GtfsService) DownloadGTFSBundles(ctx context.Context, servers []models.ObaServer, maxRetries int) {
+	downloadGTFSBundles(ctx, servers, gs.Logger, gs.BoundingBoxStore, gs.StaticStore, maxRetries)
 }
 
 // This service method downloads a GTFS static bundle from the provided URL,
@@ -39,12 +39,16 @@ func (gs *GtfsService) DownloadGTFSBundles(servers []models.ObaServer) {
 // but this public method can be used to download a single GTFS bundle.
 // It parses the GTFS data and stores it in the StaticStore using the serverID as the key.
 // It returns an error if the download or parsing fails.
-func (gs *GtfsService) DownloadAndStoreGTFSBundle(url string, serverID int) error {
-	return downloadAndStoreGTFSBundle(url, serverID, gs.StaticStore)
+func (gs *GtfsService) DownloadGTFSBundle(ctx context.Context, url string, serverID int, maxRetires int) (*remoteGtfs.Static, error) {
+	return downloadGTFSBundle(ctx, url, serverID, maxRetires)
 }
 
-func (gs *GtfsService) RefreshGTFSBundles(ctx context.Context, servers []models.ObaServer, interval time.Duration) {
-	refreshGTFSBundles(ctx, servers, gs.Logger, interval, gs.BoundingBoxStore, gs.StaticStore)
+func (gs *GtfsService) StoreGTFSBundle(staticBundle *remoteGtfs.Static, serverID int) error {
+	return storeGTFSBundle(staticBundle, serverID, gs.StaticStore, gs.BoundingBoxStore)
+}
+
+func (gs *GtfsService) RefreshGTFSBundles(ctx context.Context, servers []models.ObaServer, interval time.Duration, maxRetries int) {
+	refreshGTFSBundles(ctx, servers, gs.Logger, interval, gs.BoundingBoxStore, gs.StaticStore, maxRetries)
 }
 
 func (gs *GtfsService) FetchAndStoreGTFSRTFeed(server models.ObaServer) error {

--- a/internal/metrics/metrics_service.go
+++ b/internal/metrics/metrics_service.go
@@ -46,8 +46,8 @@ func (ms *MetricsService) CheckBundleExpiration(currentTime time.Time, server mo
 	return checkBundleExpiration(ms.StaticStore, currentTime, server)
 }
 
-func (ms *MetricsService) ServerPing(server models.ObaServer) {
-	serverPing(server)
+func (ms *MetricsService) ServerPing(server models.ObaServer) bool {
+	return serverPing(server)
 }
 
 func (ms *MetricsService) FetchObaAPIMetrics(slugID string, serverID int, serverBaseUrl string, apiKey string) error {

--- a/internal/metrics/server_ping.go
+++ b/internal/metrics/server_ping.go
@@ -24,7 +24,7 @@ import (
 //
 // Returns:
 //   - None (side effects include reporting to Prometheus and Sentry).
-func serverPing(server models.ObaServer) {
+func serverPing(server models.ObaServer) bool {
 	client := onebusaway.NewClient(
 		option.WithAPIKey(server.ObaApiKey),
 		option.WithBaseURL(server.ObaBaseURL),
@@ -46,7 +46,7 @@ func serverPing(server models.ObaServer) {
 			strconv.Itoa(server.ID),
 			server.ObaBaseURL,
 		).Set(0)
-		return
+		return false
 	}
 
 	// Check response validity
@@ -55,10 +55,11 @@ func serverPing(server models.ObaServer) {
 			strconv.Itoa(server.ID),
 			server.ObaBaseURL,
 		).Set(1)
-	} else {
-		ObaApiStatus.WithLabelValues(
-			strconv.Itoa(server.ID),
-			server.ObaBaseURL,
-		).Set(0)
+		return true
 	}
+	ObaApiStatus.WithLabelValues(
+		strconv.Itoa(server.ID),
+		server.ObaBaseURL,
+	).Set(0)
+	return false
 }


### PR DESCRIPTION
## Changes
* Implement `BackoffStore` with jitter and max backoff
  * Use it in the main metrics collection routine, storing the `NextRetryAt` and `BackoffDelay` for each server
* Add `DoWithBackoff` helper for HTTP requests (config + GTFS)
  * Use it with loading and refreshing configuration and downloading GTFS bundles
* Refactor GTFS bundle handling with backoff and concurrency
* Update `refreshConfig` to avoid ticker/backoff overlap issue

## Note 

**We should care about double backoff if upstream has retry+backoff**

* If the upstream OBA server or load balancer already applies its own retry/backoff strategy, layering another one on top can multiply delays unnecessarily.
* Example: the server retries internally (100ms, 200ms, 400ms…), and our client also does exponential backoff (1s, 2s, 4s…).
* Worst case: overall latency balloons without adding much resilience.
