### PR TITLE
fix: validate coordinates with isValidLatLon before S2 clustering

### DIFF
--- a/internal/geo/geo_cluster.go
+++ b/internal/geo/geo_cluster.go
@@ -74,7 +74,8 @@ func getClusterID(stop remoteGtfs.Stop) (clusterID string, clusterType string, o
 				return root.Id, "station", true
 			}
 			return "", "", false // malformed hierarchy
-		} else if stop.Latitude != nil && stop.Longitude != nil {
+		} else if stop.Latitude != nil && stop.Longitude != nil &&
+			isValidLatLon(*stop.Latitude, *stop.Longitude) {
 			return s2ClusterID(*stop.Latitude, *stop.Longitude, s2Level), "s2", true
 		}
 	case 1: // Station
@@ -88,7 +89,8 @@ func getClusterID(stop remoteGtfs.Stop) (clusterID string, clusterType string, o
 		if stop.Parent != nil && stop.Parent.Type == 0 {
 			grandparent := stop.Parent.Parent
 			if grandparent == nil {
-				if stop.Latitude != nil && stop.Longitude != nil {
+				if stop.Latitude != nil && stop.Longitude != nil &&
+					isValidLatLon(*stop.Latitude, *stop.Longitude) {
 					return s2ClusterID(*stop.Latitude, *stop.Longitude, s2Level), "s2", true
 				}
 				return "", "", false

--- a/internal/geo/geo_cluster_test.go
+++ b/internal/geo/geo_cluster_test.go
@@ -1,0 +1,24 @@
+package geo
+
+import (
+    "testing"
+
+    remoteGtfs "github.com/jamespfennell/gtfs"
+)
+
+func float64Ptr(f float64) *float64 { return &f }
+
+func TestGetClusterID_ZeroCoordinates(t *testing.T) {
+    t.Run("Stop with (0,0) coordinates should not S2 cluster", func(t *testing.T) {
+        stop := remoteGtfs.Stop{
+            Id:        "zero-coord-stop",
+            Type:      0,
+            Latitude:  float64Ptr(0.0),
+            Longitude: float64Ptr(0.0),
+        }
+        _, _, ok := getClusterID(stop)
+        if ok {
+            t.Error("Expected ok=false for (0,0) coordinates, got true")
+        }
+    })
+}


### PR DESCRIPTION
The getClusterID function was producing S2 cluster IDs for stops with coordinates (0,0), which is typically a placeholder for improperly formatted GTFS data.

I noticed that the geo package already includes a validation check with the function “isValidLatLon,” but this is not currently used in the S2 clustering path for the aforementioned stops.

This PR includes the validation check in the 0 and 4 cases of the S2 fallback path, as well as a test to ensure that the previous incorrect behavior is now working as expected.