### PR TITLE
test: Add unit tests for middleware

### DIFF
--- a/internal/middleware/cached_prom_handler_test.go
+++ b/internal/middleware/cached_prom_handler_test.go
@@ -1,0 +1,86 @@
+package middleware
+
+// cached_prom_handler_test.go contains unit tests for the CachedPromHandler
+// defined in cached_prom_handler.go.
+//
+// Author: Zala Vishmayraj
+//
+// Run tests:
+//   go test ./internal/middleware/... -run TestCachedPromHandler
+//   go test ./internal/middleware/... -run TestCachedPromHandler -v
+//   go test ./internal/middleware/... -race (concurrent safety)
+
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func TestCachedPromHandler(t *testing.T) {
+	t.Run("Empty cache falls back to live handler", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		registry := prometheus.NewRegistry()
+		handler := NewCachedPromHandler(ctx, registry, 10*time.Second)
+
+		req := httptest.NewRequest("GET", "/metrics", nil)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		if rec.Code != 200 {
+			t.Errorf("Expected status 200, got %d", rec.Code)
+		}
+	})
+
+	t.Run("Populated cache serves cached content with correct Content-Type", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		registry := prometheus.NewRegistry()
+		handler := NewCachedPromHandler(ctx, registry, 50*time.Millisecond)
+
+		// Wait for the cache to be populated by the refresh loop
+		time.Sleep(200 * time.Millisecond)
+
+		req := httptest.NewRequest("GET", "/metrics", nil)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		if rec.Code != 200 {
+			t.Errorf("Expected status 200, got %d", rec.Code)
+		}
+
+		contentType := rec.Header().Get("Content-Type")
+		if !strings.Contains(contentType, "text/plain") {
+			t.Errorf("Expected Content-Type to contain text/plain, got %q", contentType)
+		}
+	})
+
+	t.Run("Concurrent reads do not race", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		registry := prometheus.NewRegistry()
+		handler := NewCachedPromHandler(ctx, registry, 50*time.Millisecond)
+
+		time.Sleep(200 * time.Millisecond)
+
+		var wg sync.WaitGroup
+		for i := 0; i < 50; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				req := httptest.NewRequest("GET", "/metrics", nil)
+				rec := httptest.NewRecorder()
+				handler.ServeHTTP(rec, req)
+			}()
+		}
+		wg.Wait()
+	})
+}

--- a/internal/middleware/security_middleware_test.go
+++ b/internal/middleware/security_middleware_test.go
@@ -1,0 +1,59 @@
+package middleware
+
+// security_middleware_test.go contains unit tests for the SecurityHeaders middleware
+// defined in security_middleware.go.
+//
+// Author: Zala Vishmayraj
+//
+// Run tests:
+//   go test ./internal/middleware/... -run TestSecurityHeaders
+//   go test ./internal/middleware/... -run TestSecurityHeaders -v
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestSecurityHeaders(t *testing.T) {
+	t.Run("All security headers are set with correct values", func(t *testing.T) {
+		next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+		handler := SecurityHeaders(next)
+
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		expectedHeaders := map[string]string{
+			"X-Content-Type-Options":        "nosniff",
+			"Cache-Control":                 "no-store, no-cache, must-revalidate",
+			"Pragma":                        "no-cache",
+			"Cross-Origin-Opener-Policy":    "same-origin",
+			"Cross-Origin-Resource-Policy":  "same-origin",
+			"X-XSS-Protection":              "1; mode=block",
+			"Content-Security-Policy":       "default-src 'self'",
+		}
+
+		for header, expected := range expectedHeaders {
+			got := rec.Header().Get(header)
+			if got != expected {
+				t.Errorf("Header %q: expected %q, got %q", header, expected, got)
+			}
+		}
+	})
+
+	t.Run("Next handler is called and response passes through", func(t *testing.T) {
+		next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusTeapot)
+		})
+		handler := SecurityHeaders(next)
+
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusTeapot {
+			t.Errorf("Expected status %d, got %d", http.StatusTeapot, rec.Code)
+		}
+	})
+}


### PR DESCRIPTION
`internal/middleware` had no test coverage. This PR adds tests for:

`SecurityHeaders`: verifies all 7 security headers are set with correct 
values, and that the next handler is called correctly.

`CachedPromHandler`: verifies empty cache fallback, correct Content-Type 
when cache is populated, and concurrent read safety (verified with -race).

`SentryMiddleware` is intentionally skipped — it wraps a third-party SDK 
with no testable surface without mocking Sentry internals.

All existing tests continue to pass.