### PR TITLE
Migrate to oba gtfs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,10 @@ module watchdog.onebusaway.org
 go 1.23.5
 
 require (
+	github.com/OneBusAway/go-gtfs v1.1.1
 	github.com/OneBusAway/go-sdk v0.1.0-alpha.13
 	github.com/getsentry/sentry-go v0.33.0
 	github.com/golang/geo v0.0.0-20250707181242-c5087ca84cf4
-	github.com/jamespfennell/gtfs v0.1.24
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/prometheus/client_golang v1.20.5
 	github.com/prometheus/client_model v0.6.1

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/OneBusAway/go-gtfs v1.1.1 h1:JWl0ndXHBED6PAh8v3w0UgSDYWBg2OmHvAJb5RXX3Ss=
+github.com/OneBusAway/go-gtfs v1.1.1/go.mod h1:MJqNyFOJs+iE1R6uerTyfBY6g3/sxvTvVdRhDeN1bu8=
 github.com/OneBusAway/go-sdk v0.1.0-alpha.13 h1:xQdZjREPJTON4XKoQpUf9YTm8KCVsLJyOW9LkldyquY=
 github.com/OneBusAway/go-sdk v0.1.0-alpha.13/go.mod h1:h1TnOvie6gN5gi0no/0w6nPg1jbidz2D+Osyq72R60Q=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -15,12 +17,6 @@ github.com/golang/geo v0.0.0-20250707181242-c5087ca84cf4 h1:vCeHcs8N7MOccOOsOVIy
 github.com/golang/geo v0.0.0-20250707181242-c5087ca84cf4/go.mod h1:AN0OjM34c3PbjAsX+QNma1nYtJtRxl+s9MZNV7S+efw=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
-github.com/golang/geo v0.0.0-20250707181242-c5087ca84cf4 h1:vCeHcs8N7MOccOOsOVIy1xcYu+kBkA4J5urTgigww7c=
-github.com/golang/geo v0.0.0-20250707181242-c5087ca84cf4/go.mod h1:AN0OjM34c3PbjAsX+QNma1nYtJtRxl+s9MZNV7S+efw=
-github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
-github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
-github.com/jamespfennell/gtfs v0.1.24 h1:em/W8Bg88xZwX70r7FoghMiuZDn3m5oj0EfqmikU1Io=
-github.com/jamespfennell/gtfs v0.1.24/go.mod h1:nj9QFIc695IUKM5djZXzyPtCIAYxufafb0sQNbiVMOs=
 github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4dN7jwJOQ1U=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/klauspost/compress v1.17.11 h1:In6xLpyWOi1+C7tXUUWv2ot1QvBjxevKAaI6IXrJmUc=

--- a/internal/app/test_helpers.go
+++ b/internal/app/test_helpers.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	obaGtfs "github.com/OneBusAway/go-gtfs"
+	remoteGtfs "github.com/OneBusAway/go-gtfs"
 	"github.com/prometheus/client_golang/prometheus"
 	"watchdog.onebusaway.org/internal/config"
 	"watchdog.onebusaway.org/internal/geo"
@@ -49,7 +49,7 @@ func newTestApplication(t *testing.T) *Application {
 	if err != nil {
 		t.Fatalf("Failed to read GTFS fixture: %v", err)
 	}
-	staticBundle, err := obaGtfs.ParseStatic(fileBytes, obaGtfs.ParseStaticOptions{})
+	staticBundle, err := remoteGtfs.ParseStatic(fileBytes, remoteGtfs.ParseStaticOptions{})
 	if err != nil {
 		t.Fatalf("Failed to parse GTFS data: %v", err)
 	}
@@ -75,7 +75,7 @@ func newTestApplication(t *testing.T) *Application {
 	if err != nil {
 		t.Fatalf("Failed to read GTFS-RT fixture: %v", err)
 	}
-	gtfsRT, err := obaGtfs.ParseRealtime(data, &obaGtfs.ParseRealtimeOptions{})
+	gtfsRT, err := remoteGtfs.ParseRealtime(data, &remoteGtfs.ParseRealtimeOptions{})
 	if err != nil {
 		t.Fatalf("Failed to parse GTFS-RT data: %v", err)
 	}

--- a/internal/app/test_helpers.go
+++ b/internal/app/test_helpers.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	remoteGtfs "github.com/jamespfennell/gtfs"
+	obaGtfs "github.com/OneBusAway/go-gtfs"
 	"github.com/prometheus/client_golang/prometheus"
 	"watchdog.onebusaway.org/internal/config"
 	"watchdog.onebusaway.org/internal/geo"
@@ -49,7 +49,7 @@ func newTestApplication(t *testing.T) *Application {
 	if err != nil {
 		t.Fatalf("Failed to read GTFS fixture: %v", err)
 	}
-	staticBundle, err := remoteGtfs.ParseStatic(fileBytes, remoteGtfs.ParseStaticOptions{})
+	staticBundle, err := obaGtfs.ParseStatic(fileBytes, obaGtfs.ParseStaticOptions{})
 	if err != nil {
 		t.Fatalf("Failed to parse GTFS data: %v", err)
 	}
@@ -75,7 +75,7 @@ func newTestApplication(t *testing.T) *Application {
 	if err != nil {
 		t.Fatalf("Failed to read GTFS-RT fixture: %v", err)
 	}
-	gtfsRT, err := remoteGtfs.ParseRealtime(data, &remoteGtfs.ParseRealtimeOptions{})
+	gtfsRT, err := obaGtfs.ParseRealtime(data, &obaGtfs.ParseRealtimeOptions{})
 	if err != nil {
 		t.Fatalf("Failed to parse GTFS-RT data: %v", err)
 	}

--- a/internal/geo/geo_cluster.go
+++ b/internal/geo/geo_cluster.go
@@ -3,7 +3,7 @@ package geo
 import (
 	"fmt"
 
-	obaGtfs "github.com/OneBusAway/go-gtfs"
+	remoteGtfs "github.com/OneBusAway/go-gtfs"
 	"github.com/golang/geo/s2"
 )
 
@@ -65,7 +65,7 @@ func s2ClusterID(lat, lon float64, level int) string {
 //   - Invalid: grandparent exists but is not a Station, or coordinates are missing for fallback - data is malformed.
 //
 // Returns false if hierarchy rules are violated or required parent/coordinate data is missing.
-func getClusterID(stop obaGtfs.Stop) (clusterID string, clusterType string, ok bool) {
+func getClusterID(stop remoteGtfs.Stop) (clusterID string, clusterType string, ok bool) {
 	switch stop.Type {
 	case 0: // Stop or Platform
 		if stop.Parent != nil {

--- a/internal/geo/geo_cluster.go
+++ b/internal/geo/geo_cluster.go
@@ -3,8 +3,8 @@ package geo
 import (
 	"fmt"
 
+	obaGtfs "github.com/OneBusAway/go-gtfs"
 	"github.com/golang/geo/s2"
-	remoteGtfs "github.com/jamespfennell/gtfs"
 )
 
 const s2Level = 13 // S2 cell level with 850–1225 m spatial resolution
@@ -65,7 +65,7 @@ func s2ClusterID(lat, lon float64, level int) string {
 //   - Invalid: grandparent exists but is not a Station, or coordinates are missing for fallback - data is malformed.
 //
 // Returns false if hierarchy rules are violated or required parent/coordinate data is missing.
-func getClusterID(stop remoteGtfs.Stop) (clusterID string, clusterType string, ok bool) {
+func getClusterID(stop obaGtfs.Stop) (clusterID string, clusterType string, ok bool) {
 	switch stop.Type {
 	case 0: // Stop or Platform
 		if stop.Parent != nil {

--- a/internal/geo/geo_service.go
+++ b/internal/geo/geo_service.go
@@ -1,7 +1,7 @@
 package geo
 
 import (
-	obaGtfs "github.com/OneBusAway/go-gtfs"
+	remoteGtfs "github.com/OneBusAway/go-gtfs"
 )
 
 // For now geo package only exposes helper functions to be used by other packages.
@@ -19,7 +19,7 @@ import (
 
 // Wrappers for utility functions
 
-func ComputeBoundingBox(stops []obaGtfs.Stop) (BoundingBox, error) {
+func ComputeBoundingBox(stops []remoteGtfs.Stop) (BoundingBox, error) {
 	return computeBoundingBox(stops)
 }
 
@@ -31,6 +31,6 @@ func HaversineDistance(lat1, lon1, lat2, lon2 float64) float64 {
 	return haversineDistance(lat1, lon1, lat2, lon2)
 }
 
-func GetClusterID(stop obaGtfs.Stop) (clusterID string, clusterType string, ok bool) {
+func GetClusterID(stop remoteGtfs.Stop) (clusterID string, clusterType string, ok bool) {
 	return getClusterID(stop)
 }

--- a/internal/geo/geo_service.go
+++ b/internal/geo/geo_service.go
@@ -1,7 +1,7 @@
 package geo
 
 import (
-	remoteGtfs "github.com/jamespfennell/gtfs"
+	obaGtfs "github.com/OneBusAway/go-gtfs"
 )
 
 // For now geo package only exposes helper functions to be used by other packages.
@@ -19,7 +19,7 @@ import (
 
 // Wrappers for utility functions
 
-func ComputeBoundingBox(stops []remoteGtfs.Stop) (BoundingBox, error) {
+func ComputeBoundingBox(stops []obaGtfs.Stop) (BoundingBox, error) {
 	return computeBoundingBox(stops)
 }
 
@@ -31,6 +31,6 @@ func HaversineDistance(lat1, lon1, lat2, lon2 float64) float64 {
 	return haversineDistance(lat1, lon1, lat2, lon2)
 }
 
-func GetClusterID(stop remoteGtfs.Stop) (clusterID string, clusterType string, ok bool) {
+func GetClusterID(stop obaGtfs.Stop) (clusterID string, clusterType string, ok bool) {
 	return getClusterID(stop)
 }

--- a/internal/geo/geo_utils.go
+++ b/internal/geo/geo_utils.go
@@ -8,8 +8,8 @@ import (
 	"math"
 	"sync"
 
+	obaGtfs "github.com/OneBusAway/go-gtfs"
 	"github.com/golang/geo/s2"
-	remoteGtfs "github.com/jamespfennell/gtfs"
 )
 
 // BoundingBox defines the geographic boundaries of a rectangular area.
@@ -29,7 +29,7 @@ func (b *BoundingBox) Contains(lat, lon float64) bool {
 // computeBoundingBox returns the bounding box enclosing all valid stops.
 //
 // It returns an error if the input slice is empty or contains no valid lat/lon pairs.
-func computeBoundingBox(stops []remoteGtfs.Stop) (BoundingBox, error) {
+func computeBoundingBox(stops []obaGtfs.Stop) (BoundingBox, error) {
 	if len(stops) == 0 {
 		return BoundingBox{}, fmt.Errorf("no stops to compute bounding box")
 	}
@@ -41,8 +41,8 @@ func computeBoundingBox(stops []remoteGtfs.Stop) (BoundingBox, error) {
 
 	for _, stop := range stops {
 		if stop.Latitude != nil && stop.Longitude != nil {
-			lat := float64(*stop.Latitude)
-			lon := float64(*stop.Longitude)
+			lat := *stop.Latitude
+			lon := *stop.Longitude
 			if lat < minLat {
 				minLat = lat
 			}

--- a/internal/geo/geo_utils.go
+++ b/internal/geo/geo_utils.go
@@ -8,7 +8,7 @@ import (
 	"math"
 	"sync"
 
-	obaGtfs "github.com/OneBusAway/go-gtfs"
+	remoteGtfs "github.com/OneBusAway/go-gtfs"
 	"github.com/golang/geo/s2"
 )
 
@@ -29,7 +29,7 @@ func (b *BoundingBox) Contains(lat, lon float64) bool {
 // computeBoundingBox returns the bounding box enclosing all valid stops.
 //
 // It returns an error if the input slice is empty or contains no valid lat/lon pairs.
-func computeBoundingBox(stops []obaGtfs.Stop) (BoundingBox, error) {
+func computeBoundingBox(stops []remoteGtfs.Stop) (BoundingBox, error) {
 	if len(stops) == 0 {
 		return BoundingBox{}, fmt.Errorf("no stops to compute bounding box")
 	}

--- a/internal/gtfs/gtfs_bundles.go
+++ b/internal/gtfs/gtfs_bundles.go
@@ -11,8 +11,8 @@ import (
 	"sync"
 	"time"
 
+	obaGtfs "github.com/OneBusAway/go-gtfs"
 	"github.com/getsentry/sentry-go"
-	remoteGtfs "github.com/jamespfennell/gtfs"
 	"watchdog.onebusaway.org/internal/config"
 	"watchdog.onebusaway.org/internal/geo"
 	"watchdog.onebusaway.org/internal/models"
@@ -137,7 +137,7 @@ func refreshGTFSBundles(ctx context.Context, servers []models.ObaServer, logger 
 //   - gtfs static data
 //   - error: Describes what went wrong, or nil if the operation was successful.
 
-func downloadGTFSBundle(ctx context.Context, url string, serverID int, maxRetries int) (*remoteGtfs.Static, error) {
+func downloadGTFSBundle(ctx context.Context, url string, serverID int, maxRetries int) (*obaGtfs.Static, error) {
 	client := &http.Client{Timeout: 10 * time.Second}
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
@@ -184,7 +184,7 @@ func downloadGTFSBundle(ctx context.Context, url string, serverID int, maxRetrie
 		return nil, err
 	}
 
-	staticBundle, err := remoteGtfs.ParseStatic(data, remoteGtfs.ParseStaticOptions{})
+	staticBundle, err := obaGtfs.ParseStatic(data, obaGtfs.ParseStaticOptions{})
 	if err != nil {
 		err = fmt.Errorf("failed to parse GTFS static data from %s: %w", url, err)
 		report.ReportErrorWithSentryOptions(err, report.SentryReportOptions{
@@ -217,7 +217,7 @@ func downloadGTFSBundle(ctx context.Context, url string, serverID int, maxRetrie
 // Returns:
 //   - error: If computing the bounding box fails, an error is returned. Otherwise, nil.
 
-func storeGTFSBundle(staticBundle *remoteGtfs.Static, serverID int, staticStore *StaticStore, boundingBoxStore *geo.BoundingBoxStore) error {
+func storeGTFSBundle(staticBundle *obaGtfs.Static, serverID int, staticStore *StaticStore, boundingBoxStore *geo.BoundingBoxStore) error {
 	// StaticData is a wrapper around the GTFS static bundle
 	// that includes only the parts we use in the application.
 	// So we do not keep the whole GTFS static bundle in memory,
@@ -238,7 +238,7 @@ func storeGTFSBundle(staticBundle *remoteGtfs.Static, serverID int, staticStore 
 // getStopLocationsByIDs retrieves stop locations by their IDs from the GTFS cache.
 // It returns a map of stop IDs to gtfs.Stop objects.
 
-func getStopLocationsByIDs(serverID int, stopIDs []string, staticStore *StaticStore) (map[string]remoteGtfs.Stop, error) {
+func getStopLocationsByIDs(serverID int, stopIDs []string, staticStore *StaticStore) (map[string]obaGtfs.Stop, error) {
 	staticData, ok := staticStore.Get(serverID)
 	if !ok || staticData == nil {
 		err := fmt.Errorf("no GTFS static data found for server ID %d", serverID)
@@ -253,7 +253,7 @@ func getStopLocationsByIDs(serverID int, stopIDs []string, staticStore *StaticSt
 		stopIDSet[id] = struct{}{}
 	}
 
-	result := make(map[string]remoteGtfs.Stop)
+	result := make(map[string]obaGtfs.Stop)
 	for _, stop := range staticData.Stops {
 		if _, exists := stopIDSet[stop.Id]; exists {
 			result[stop.Id] = stop
@@ -312,7 +312,7 @@ func fetchAndStoreGTFSRTFeed(server models.ObaServer, realtimeStore *RealtimeSto
 		return err
 	}
 
-	gtfsRT, err := remoteGtfs.ParseRealtime(data, &remoteGtfs.ParseRealtimeOptions{})
+	gtfsRT, err := obaGtfs.ParseRealtime(data, &obaGtfs.ParseRealtimeOptions{})
 	if err != nil {
 		report.ReportError(err)
 		return err

--- a/internal/gtfs/gtfs_bundles.go
+++ b/internal/gtfs/gtfs_bundles.go
@@ -11,7 +11,7 @@ import (
 	"sync"
 	"time"
 
-	obaGtfs "github.com/OneBusAway/go-gtfs"
+	remoteGtfs "github.com/OneBusAway/go-gtfs"
 	"github.com/getsentry/sentry-go"
 	"watchdog.onebusaway.org/internal/config"
 	"watchdog.onebusaway.org/internal/geo"
@@ -137,7 +137,7 @@ func refreshGTFSBundles(ctx context.Context, servers []models.ObaServer, logger 
 //   - gtfs static data
 //   - error: Describes what went wrong, or nil if the operation was successful.
 
-func downloadGTFSBundle(ctx context.Context, url string, serverID int, maxRetries int) (*obaGtfs.Static, error) {
+func downloadGTFSBundle(ctx context.Context, url string, serverID int, maxRetries int) (*remoteGtfs.Static, error) {
 	client := &http.Client{Timeout: 10 * time.Second}
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
@@ -184,7 +184,7 @@ func downloadGTFSBundle(ctx context.Context, url string, serverID int, maxRetrie
 		return nil, err
 	}
 
-	staticBundle, err := obaGtfs.ParseStatic(data, obaGtfs.ParseStaticOptions{})
+	staticBundle, err := remoteGtfs.ParseStatic(data, remoteGtfs.ParseStaticOptions{})
 	if err != nil {
 		err = fmt.Errorf("failed to parse GTFS static data from %s: %w", url, err)
 		report.ReportErrorWithSentryOptions(err, report.SentryReportOptions{
@@ -217,7 +217,7 @@ func downloadGTFSBundle(ctx context.Context, url string, serverID int, maxRetrie
 // Returns:
 //   - error: If computing the bounding box fails, an error is returned. Otherwise, nil.
 
-func storeGTFSBundle(staticBundle *obaGtfs.Static, serverID int, staticStore *StaticStore, boundingBoxStore *geo.BoundingBoxStore) error {
+func storeGTFSBundle(staticBundle *remoteGtfs.Static, serverID int, staticStore *StaticStore, boundingBoxStore *geo.BoundingBoxStore) error {
 	// StaticData is a wrapper around the GTFS static bundle
 	// that includes only the parts we use in the application.
 	// So we do not keep the whole GTFS static bundle in memory,
@@ -238,7 +238,7 @@ func storeGTFSBundle(staticBundle *obaGtfs.Static, serverID int, staticStore *St
 // getStopLocationsByIDs retrieves stop locations by their IDs from the GTFS cache.
 // It returns a map of stop IDs to gtfs.Stop objects.
 
-func getStopLocationsByIDs(serverID int, stopIDs []string, staticStore *StaticStore) (map[string]obaGtfs.Stop, error) {
+func getStopLocationsByIDs(serverID int, stopIDs []string, staticStore *StaticStore) (map[string]remoteGtfs.Stop, error) {
 	staticData, ok := staticStore.Get(serverID)
 	if !ok || staticData == nil {
 		err := fmt.Errorf("no GTFS static data found for server ID %d", serverID)
@@ -253,7 +253,7 @@ func getStopLocationsByIDs(serverID int, stopIDs []string, staticStore *StaticSt
 		stopIDSet[id] = struct{}{}
 	}
 
-	result := make(map[string]obaGtfs.Stop)
+	result := make(map[string]remoteGtfs.Stop)
 	for _, stop := range staticData.Stops {
 		if _, exists := stopIDSet[stop.Id]; exists {
 			result[stop.Id] = stop
@@ -312,7 +312,7 @@ func fetchAndStoreGTFSRTFeed(server models.ObaServer, realtimeStore *RealtimeSto
 		return err
 	}
 
-	gtfsRT, err := obaGtfs.ParseRealtime(data, &obaGtfs.ParseRealtimeOptions{})
+	gtfsRT, err := remoteGtfs.ParseRealtime(data, &remoteGtfs.ParseRealtimeOptions{})
 	if err != nil {
 		report.ReportError(err)
 		return err

--- a/internal/gtfs/gtfs_bundles_test.go
+++ b/internal/gtfs/gtfs_bundles_test.go
@@ -56,6 +56,46 @@ func TestDownloadGTFSBundle(t *testing.T) {
 		if staticBundle == nil {
 			t.Fatal("static data retrieved from the store is nil; expected non-nil value")
 		}
+		data := readFixture(t, "gtfs.zip")
+		expectedStaticData, err := remoteGtfs.ParseStatic(data, remoteGtfs.ParseStaticOptions{})
+		if err != nil {
+			t.Fatalf("failed to parse expected GTFS static data from fixture: %v", err)
+		}
+		if expectedStaticData == nil {
+			t.Fatal("parsed expected static data is nil; expected valid GTFS data")
+		}
+		if expectedStaticData.Agencies == nil {
+			t.Fatal("expected static data has nil Agencies slice; expected it to be parsed")
+		}
+
+		// For simplicity, we validate the content of agency.txt by comparing the agency IDs.
+		// We assume that if the agency IDs match, the GTFS static data was parsed and stored correctly.
+		// This level of verification is sufficient for this test.
+		//
+		// Note: We rely on agency.txt as it is a required GTFS file.
+		// Make sure the test data provided includes a non-empty agency.txt file.
+
+		if len(expectedStaticData.Agencies) != len(staticBundle.Agencies) {
+			t.Fatalf("expected %d agencies, got %d", len(expectedStaticData.Agencies), len(staticBundle.Agencies))
+		}
+		if len(expectedStaticData.Agencies) == 0 {
+			t.Fatal("expected Agencies slice is empty; can't verify content consistency")
+		}
+		expectedAgencyIDs := make(map[string]struct{})
+		for _, agency := range expectedStaticData.Agencies {
+			expectedAgencyIDs[agency.Id] = struct{}{}
+		}
+		if staticBundle.Agencies == nil {
+			t.Fatal("stored static data has nil Agencies slice; expected it to be populated")
+		}
+		if len(staticBundle.Agencies) == 0 {
+			t.Fatal("stored Agencies slice is empty; static data likely not parsed correctly")
+		}
+		for _, agency := range staticBundle.Agencies {
+			if _, ok := expectedAgencyIDs[agency.Id]; !ok {
+				t.Fatalf("unexpected agency ID %s found in stored static data", agency.Id)
+			}
+		}
 	})
 
 	t.Run("Invalid URL", func(t *testing.T) {
@@ -99,40 +139,34 @@ func TestAgencyParsing(t *testing.T) {
 		t.Fatalf("expected %d agencies, got %d", len(expectedStaticAgencies), len(staticBundle.Agencies))
 	}
 
-	expectedAgencyIDs := make(map[string]struct {
-		Name      string
-		TimeZone  string
-		AgencyUrl string
-	})
+	expectedAgencies := make(map[string]remoteGtfs.Agency)
 
 	for _, agency := range expectedStaticAgencies {
-		expectedAgencyIDs[agency.Id] = struct {
-			Name      string
-			TimeZone  string
-			AgencyUrl string
-		}{
-			Name:      agency.Name,
-			TimeZone:  agency.Timezone,
-			AgencyUrl: agency.Url,
+		expectedAgencies[agency.Id] = remoteGtfs.Agency{
+			Id:       agency.Id,
+			Name:     agency.Name,
+			Timezone: agency.Timezone,
+			Url:      agency.Url,
+			FareUrl:  agency.FareUrl,
+			Language: agency.Language,
+			Phone:    agency.Phone,
+			Email:    agency.Email,
 		}
 	}
+
 	for _, agency := range staticBundle.Agencies {
-		agc_data, ok := expectedAgencyIDs[agency.Id]
+		expectedAgency, ok := expectedAgencies[agency.Id]
 		if !ok {
 			t.Fatalf("unexpected agency ID %s", agency.Id)
 		}
 
-		if agc_data.Name != agency.Name {
-			t.Errorf("agency %s name mismatch: expected %s, got %s",
-				agency.Id, agc_data.Name, agency.Name)
-		}
-
-		if agc_data.TimeZone != agency.Timezone {
-			t.Errorf("agency %s timezone mismatch", agency.Id)
-		}
-
-		if agc_data.AgencyUrl != agency.Url {
-			t.Errorf("agency %s URL mismatch", agency.Id)
+		if expectedAgency != agency {
+			t.Errorf(
+				"agency mismatch for ID %s expected: %+v got %+v",
+				agency.Id,
+				expectedAgency,
+				agency,
+			)
 		}
 	}
 }

--- a/internal/gtfs/gtfs_bundles_test.go
+++ b/internal/gtfs/gtfs_bundles_test.go
@@ -171,6 +171,9 @@ func TestGetStopLocationsByIDs(t *testing.T) {
 			if !ok {
 				t.Fatalf("unexpected stop ID returned: %s", stop.Id)
 			}
+			if stop.Latitude == nil || stop.Longitude == nil {
+				t.Fatalf("stop %s missing coordinates", stop.Id)
+			}
 
 			if stop.Name != expected.stopName {
 				t.Errorf("stop %s name mismatch: expected %s, got %s",

--- a/internal/gtfs/gtfs_bundles_test.go
+++ b/internal/gtfs/gtfs_bundles_test.go
@@ -82,9 +82,21 @@ func TestDownloadGTFSBundle(t *testing.T) {
 		if len(expectedStaticData.Agencies) == 0 {
 			t.Fatal("expected Agencies slice is empty; can't verify content consistency")
 		}
-		expectedAgencyIDs := make(map[string]struct{})
+		expectedAgencyIDs := make(map[string]struct {
+			Name      string
+			TimeZone  string
+			AgencyUrl string
+		})
 		for _, agency := range expectedStaticData.Agencies {
-			expectedAgencyIDs[agency.Id] = struct{}{}
+			expectedAgencyIDs[agency.Id] = struct {
+				Name      string
+				TimeZone  string
+				AgencyUrl string
+			}{
+				Name:      agency.Name,
+				TimeZone:  agency.Timezone,
+				AgencyUrl: agency.Url,
+			}
 		}
 		if staticBundle.Agencies == nil {
 			t.Fatal("stored static data has nil Agencies slice; expected it to be populated")
@@ -93,8 +105,22 @@ func TestDownloadGTFSBundle(t *testing.T) {
 			t.Fatal("stored Agencies slice is empty; static data likely not parsed correctly")
 		}
 		for _, agency := range staticBundle.Agencies {
-			if _, ok := expectedAgencyIDs[agency.Id]; !ok {
-				t.Fatalf("unexpected agency ID %s found in stored static data", agency.Id)
+			agc_data, ok := expectedAgencyIDs[agency.Id]
+			if !ok {
+				t.Fatalf("unexpected agency ID %s", agency.Id)
+			}
+
+			if agc_data.Name != agency.Name {
+				t.Errorf("agency %s name mismatch: expected %s, got %s",
+					agency.Id, agc_data.Name, agency.Name)
+			}
+
+			if agc_data.TimeZone != agency.Timezone {
+				t.Errorf("agency %s timezone mismatch", agency.Id)
+			}
+
+			if agc_data.AgencyUrl != agency.Url {
+				t.Errorf("agency %s URL mismatch", agency.Id)
 			}
 		}
 	})
@@ -121,14 +147,45 @@ func TestGetStopLocationsByIDs(t *testing.T) {
 	staticStore := NewStaticStore()
 	staticStore.Set(server.ID, staticData)
 
-	t.Run("Valid stop IDs", func(t *testing.T) {
+	t.Run("Valid stops", func(t *testing.T) {
 		stopIDs := []string{"11060", "1108"} // Make sure these exist in your test GTFS
+		stopsData := map[string]struct {
+			stopName string
+			lat      float64
+			long     float64
+		}{
+			"11060": {stopName: "Broadway & E Denny Way", lat: 47.618425, long: -122.320940},
+			"1108":  {stopName: "Westlake", lat: 47.611450, long: -122.337532},
+		}
+
 		stops, err := getStopLocationsByIDs(server.ID, stopIDs, staticStore)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if len(stops) == 0 {
 			t.Fatalf("expected some matched stops, got 0")
+		}
+
+		for _, stop := range stops {
+			expected, ok := stopsData[stop.Id]
+			if !ok {
+				t.Fatalf("unexpected stop ID returned: %s", stop.Id)
+			}
+
+			if stop.Name != expected.stopName {
+				t.Errorf("stop %s name mismatch: expected %s, got %s",
+					stop.Id, expected.stopName, stop.Name)
+			}
+
+			const epsilon = 1e-5
+			if diff := *stop.Latitude - expected.lat; diff > epsilon || diff < -epsilon {
+				t.Errorf("stop %s latitude mismatch: expected %f, got %f",
+					stop.Id, expected.lat, *stop.Latitude)
+			}
+			if diff := *stop.Longitude - expected.long; diff > epsilon || diff < -epsilon {
+				t.Errorf("stop %s longitude mismatch: expected %f, got %f",
+					stop.Id, expected.long, *stop.Longitude)
+			}
 		}
 	})
 
@@ -187,19 +244,21 @@ func TestFetchAndStoreGTFSRTFeed(t *testing.T) {
 			t.Fatalf("Expected %d vehicles, got %d", len(expectedRtData.Vehicles), len(realtimeData.Vehicles))
 		}
 
-		expectedMap := make(map[string]struct{})
+		expectedMap := make(map[string]obaGtfs.Vehicle)
 		for _, vehicle := range expectedRtData.Vehicles {
 			if vehicle.ID != nil {
-				expectedMap[vehicle.ID.ID] = struct{}{}
+				expectedMap[vehicle.ID.ID] = vehicle
 			}
 		}
 		countExpectedNilIDs := len(expectedRtData.Vehicles) - len(expectedMap)
 		countNilIDs := 0
 		for _, vehicle := range realtimeData.Vehicles {
 			if vehicle.ID != nil {
-				if _, exists := expectedMap[vehicle.ID.ID]; !exists {
+				expectedVehicle, exists := expectedMap[vehicle.ID.ID]
+				if !exists {
 					t.Errorf("Unexpected vehicle ID %s found in GTFS-RT data", vehicle.ID.ID)
 				}
+				assertVehicle(t, &expectedVehicle, &vehicle)
 			} else {
 				countNilIDs++
 			}

--- a/internal/gtfs/gtfs_bundles_test.go
+++ b/internal/gtfs/gtfs_bundles_test.go
@@ -311,7 +311,7 @@ func TestFetchAndStoreGTFSRTFeed(t *testing.T) {
 				if !exists {
 					t.Errorf("Unexpected vehicle ID %s found in GTFS-RT data", vehicle.ID.ID)
 				}
-				assertVehicle(t, &expectedVehicle, &vehicle)
+				assertVehicle(t, &vehicle, &expectedVehicle)
 			} else {
 				countNilIDs++
 			}

--- a/internal/gtfs/gtfs_bundles_test.go
+++ b/internal/gtfs/gtfs_bundles_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	remoteGtfs "github.com/jamespfennell/gtfs"
+	obaGtfs "github.com/OneBusAway/go-gtfs"
 	"watchdog.onebusaway.org/internal/geo"
 	"watchdog.onebusaway.org/internal/models"
 )
@@ -58,7 +58,7 @@ func TestDownloadGTFSBundle(t *testing.T) {
 		}
 
 		data := readFixture(t, "gtfs.zip")
-		expectedStaticData, err := remoteGtfs.ParseStatic(data, remoteGtfs.ParseStaticOptions{})
+		expectedStaticData, err := obaGtfs.ParseStatic(data, obaGtfs.ParseStaticOptions{})
 		if err != nil {
 			t.Fatalf("failed to parse expected GTFS static data from fixture: %v", err)
 		}
@@ -113,7 +113,7 @@ func TestGetStopLocationsByIDs(t *testing.T) {
 	server := models.ObaServer{ID: 1, Name: "test"}
 
 	data := readFixture(t, "gtfs.zip")
-	staticBundle, err := remoteGtfs.ParseStatic(data, remoteGtfs.ParseStaticOptions{})
+	staticBundle, err := obaGtfs.ParseStatic(data, obaGtfs.ParseStaticOptions{})
 	if err != nil {
 		t.Fatal("failed to parse gtfs static data")
 	}
@@ -169,7 +169,7 @@ func TestFetchAndStoreGTFSRTFeed(t *testing.T) {
 		}
 
 		data := readFixture(t, "gtfs_rt_feed_vehicles.pb")
-		gtfsRT, err := remoteGtfs.ParseRealtime(data, &remoteGtfs.ParseRealtimeOptions{})
+		gtfsRT, err := obaGtfs.ParseRealtime(data, &obaGtfs.ParseRealtimeOptions{})
 		if err != nil {
 			t.Fatalf("Failed to parse GTFS-RT data: %v", err)
 		}

--- a/internal/gtfs/gtfs_bundles_test.go
+++ b/internal/gtfs/gtfs_bundles_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	obaGtfs "github.com/OneBusAway/go-gtfs"
+	remoteGtfs "github.com/OneBusAway/go-gtfs"
 	"watchdog.onebusaway.org/internal/geo"
 	"watchdog.onebusaway.org/internal/models"
 )
@@ -56,73 +56,6 @@ func TestDownloadGTFSBundle(t *testing.T) {
 		if staticBundle == nil {
 			t.Fatal("static data retrieved from the store is nil; expected non-nil value")
 		}
-
-		data := readFixture(t, "gtfs.zip")
-		expectedStaticData, err := obaGtfs.ParseStatic(data, obaGtfs.ParseStaticOptions{})
-		if err != nil {
-			t.Fatalf("failed to parse expected GTFS static data from fixture: %v", err)
-		}
-		if expectedStaticData == nil {
-			t.Fatal("parsed expected static data is nil; expected valid GTFS data")
-		}
-		if expectedStaticData.Agencies == nil {
-			t.Fatal("expected static data has nil Agencies slice; expected it to be parsed")
-		}
-
-		// For simplicity, we validate the content of agency.txt by comparing the agency IDs.
-		// We assume that if the agency IDs match, the GTFS static data was parsed and stored correctly.
-		// This level of verification is sufficient for this test.
-		//
-		// Note: We rely on agency.txt as it is a required GTFS file.
-		// Make sure the test data provided includes a non-empty agency.txt file.
-
-		if len(expectedStaticData.Agencies) != len(staticBundle.Agencies) {
-			t.Fatalf("expected %d agencies, got %d", len(expectedStaticData.Agencies), len(staticBundle.Agencies))
-		}
-		if len(expectedStaticData.Agencies) == 0 {
-			t.Fatal("expected Agencies slice is empty; can't verify content consistency")
-		}
-		expectedAgencyIDs := make(map[string]struct {
-			Name      string
-			TimeZone  string
-			AgencyUrl string
-		})
-		for _, agency := range expectedStaticData.Agencies {
-			expectedAgencyIDs[agency.Id] = struct {
-				Name      string
-				TimeZone  string
-				AgencyUrl string
-			}{
-				Name:      agency.Name,
-				TimeZone:  agency.Timezone,
-				AgencyUrl: agency.Url,
-			}
-		}
-		if staticBundle.Agencies == nil {
-			t.Fatal("stored static data has nil Agencies slice; expected it to be populated")
-		}
-		if len(staticBundle.Agencies) == 0 {
-			t.Fatal("stored Agencies slice is empty; static data likely not parsed correctly")
-		}
-		for _, agency := range staticBundle.Agencies {
-			agc_data, ok := expectedAgencyIDs[agency.Id]
-			if !ok {
-				t.Fatalf("unexpected agency ID %s", agency.Id)
-			}
-
-			if agc_data.Name != agency.Name {
-				t.Errorf("agency %s name mismatch: expected %s, got %s",
-					agency.Id, agc_data.Name, agency.Name)
-			}
-
-			if agc_data.TimeZone != agency.Timezone {
-				t.Errorf("agency %s timezone mismatch", agency.Id)
-			}
-
-			if agc_data.AgencyUrl != agency.Url {
-				t.Errorf("agency %s URL mismatch", agency.Id)
-			}
-		}
 	})
 
 	t.Run("Invalid URL", func(t *testing.T) {
@@ -135,11 +68,162 @@ func TestDownloadGTFSBundle(t *testing.T) {
 
 }
 
+func TestAgencyParsing(t *testing.T) {
+	data := readFixture(t, "gtfs.zip")
+	staticBundle, err := remoteGtfs.ParseStatic(data, remoteGtfs.ParseStaticOptions{})
+	if err != nil {
+		t.Fatalf("failed to parse expected GTFS static data from fixture: %v", err)
+	}
+
+	expectedStaticAgencies := []remoteGtfs.Agency{
+		{
+			Id:       "40",
+			Name:     "Sound Transit",
+			Url:      "https://www.soundtransit.org",
+			Timezone: "America/Los_Angeles",
+			Language: "en",
+			Phone:    "1-888-889-6368",
+			FareUrl:  "https://www.soundtransit.org/ride-with-us/how-to-pay/fares",
+			Email:    "main@soundtransit.org",
+		},
+	}
+
+	if staticBundle.Agencies == nil {
+		t.Fatal("stored static data has nil Agencies slice; expected it to be populated")
+	}
+	if len(staticBundle.Agencies) == 0 {
+		t.Fatal("stored Agencies slice is empty; static data likely not parsed correctly")
+	}
+
+	if len(expectedStaticAgencies) != len(staticBundle.Agencies) {
+		t.Fatalf("expected %d agencies, got %d", len(expectedStaticAgencies), len(staticBundle.Agencies))
+	}
+
+	expectedAgencyIDs := make(map[string]struct {
+		Name      string
+		TimeZone  string
+		AgencyUrl string
+	})
+
+	for _, agency := range expectedStaticAgencies {
+		expectedAgencyIDs[agency.Id] = struct {
+			Name      string
+			TimeZone  string
+			AgencyUrl string
+		}{
+			Name:      agency.Name,
+			TimeZone:  agency.Timezone,
+			AgencyUrl: agency.Url,
+		}
+	}
+	for _, agency := range staticBundle.Agencies {
+		agc_data, ok := expectedAgencyIDs[agency.Id]
+		if !ok {
+			t.Fatalf("unexpected agency ID %s", agency.Id)
+		}
+
+		if agc_data.Name != agency.Name {
+			t.Errorf("agency %s name mismatch: expected %s, got %s",
+				agency.Id, agc_data.Name, agency.Name)
+		}
+
+		if agc_data.TimeZone != agency.Timezone {
+			t.Errorf("agency %s timezone mismatch", agency.Id)
+		}
+
+		if agc_data.AgencyUrl != agency.Url {
+			t.Errorf("agency %s URL mismatch", agency.Id)
+		}
+	}
+}
+
+func TestStopsParsing(t *testing.T) {
+	server := models.ObaServer{ID: 1, Name: "test"}
+
+	data := readFixture(t, "gtfs.zip")
+	staticBundle, err := remoteGtfs.ParseStatic(data, remoteGtfs.ParseStaticOptions{})
+	if err != nil {
+		t.Fatal("failed to parse gtfs static data")
+	}
+	staticData := models.NewStaticData(staticBundle)
+	staticStore := NewStaticStore()
+	staticStore.Set(server.ID, staticData)
+	stopIDs := []string{"11060", "1108"} // Make sure these exist in your test GTFS
+	stopsData := map[string]struct {
+		stopName string
+		lat      float64
+		long     float64
+	}{
+		"11060": {stopName: "Broadway & E Denny Way", lat: 47.618425, long: -122.320940},
+		"1108":  {stopName: "Westlake", lat: 47.611450, long: -122.337532},
+	}
+
+	stops, err := getStopLocationsByIDs(server.ID, stopIDs, staticStore)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(stops) == 0 {
+		t.Fatalf("expected some matched stops, got 0")
+	}
+
+	for _, stop := range stops {
+		expected, ok := stopsData[stop.Id]
+		if !ok {
+			t.Fatalf("unexpected stop ID returned: %s", stop.Id)
+		}
+		if stop.Latitude == nil || stop.Longitude == nil {
+			t.Fatalf("stop %s missing coordinates", stop.Id)
+		}
+
+		if stop.Name != expected.stopName {
+			t.Errorf("stop %s name mismatch: expected %s, got %s",
+				stop.Id, expected.stopName, stop.Name)
+		}
+
+		const epsilon = 1e-5
+		if diff := *stop.Latitude - expected.lat; diff > epsilon || diff < -epsilon {
+			t.Errorf("stop %s latitude mismatch: expected %f, got %f",
+				stop.Id, expected.lat, *stop.Latitude)
+		}
+		if diff := *stop.Longitude - expected.long; diff > epsilon || diff < -epsilon {
+			t.Errorf("stop %s longitude mismatch: expected %f, got %f",
+				stop.Id, expected.long, *stop.Longitude)
+		}
+	}
+}
+
+func TestGetEarliestAndLatestServiceDates(t *testing.T) {
+	server := models.ObaServer{ID: 1, Name: "test"}
+	data := readFixture(t, "gtfs.zip")
+	staticBundle, err := remoteGtfs.ParseStatic(data, remoteGtfs.ParseStaticOptions{})
+	if err != nil {
+		t.Fatal("failed to parse gtfs static data")
+	}
+	staticData := models.NewStaticData(staticBundle)
+	staticStore := NewStaticStore()
+	staticStore.Set(server.ID, staticData)
+	loc, _ := time.LoadLocation("America/Los_Angeles")
+	// make sure these already exist in the test data
+	expectedEarliestEndDate := time.Date(2024, 11, 22, 0, 0, 0, 0, loc)
+	expectedLatestEndDate := time.Date(2025, 03, 28, 0, 0, 0, 0, loc)
+	actualEarliest, actualLatest, err := getEarliestAndLatestServiceDates(staticData)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !expectedEarliestEndDate.Equal(actualEarliest) {
+		t.Fatalf("earliest date mismatch: expected %s, got %s", expectedEarliestEndDate.Format("2006-01-02"), actualEarliest.Format("2006-01-02"))
+	}
+	if !expectedLatestEndDate.Equal(actualLatest) {
+		t.Fatalf("latest date mismatch: expected %s, got %s", expectedLatestEndDate.Format("2006-01-02"), actualLatest.Format("2006-01-02"))
+	}
+}
+
 func TestGetStopLocationsByIDs(t *testing.T) {
 	server := models.ObaServer{ID: 1, Name: "test"}
 
 	data := readFixture(t, "gtfs.zip")
-	staticBundle, err := obaGtfs.ParseStatic(data, obaGtfs.ParseStaticOptions{})
+	staticBundle, err := remoteGtfs.ParseStatic(data, remoteGtfs.ParseStaticOptions{})
 	if err != nil {
 		t.Fatal("failed to parse gtfs static data")
 	}
@@ -147,48 +231,14 @@ func TestGetStopLocationsByIDs(t *testing.T) {
 	staticStore := NewStaticStore()
 	staticStore.Set(server.ID, staticData)
 
-	t.Run("Valid stops", func(t *testing.T) {
+	t.Run("Valid stops IDs", func(t *testing.T) {
 		stopIDs := []string{"11060", "1108"} // Make sure these exist in your test GTFS
-		stopsData := map[string]struct {
-			stopName string
-			lat      float64
-			long     float64
-		}{
-			"11060": {stopName: "Broadway & E Denny Way", lat: 47.618425, long: -122.320940},
-			"1108":  {stopName: "Westlake", lat: 47.611450, long: -122.337532},
-		}
-
 		stops, err := getStopLocationsByIDs(server.ID, stopIDs, staticStore)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if len(stops) == 0 {
 			t.Fatalf("expected some matched stops, got 0")
-		}
-
-		for _, stop := range stops {
-			expected, ok := stopsData[stop.Id]
-			if !ok {
-				t.Fatalf("unexpected stop ID returned: %s", stop.Id)
-			}
-			if stop.Latitude == nil || stop.Longitude == nil {
-				t.Fatalf("stop %s missing coordinates", stop.Id)
-			}
-
-			if stop.Name != expected.stopName {
-				t.Errorf("stop %s name mismatch: expected %s, got %s",
-					stop.Id, expected.stopName, stop.Name)
-			}
-
-			const epsilon = 1e-5
-			if diff := *stop.Latitude - expected.lat; diff > epsilon || diff < -epsilon {
-				t.Errorf("stop %s latitude mismatch: expected %f, got %f",
-					stop.Id, expected.lat, *stop.Latitude)
-			}
-			if diff := *stop.Longitude - expected.long; diff > epsilon || diff < -epsilon {
-				t.Errorf("stop %s longitude mismatch: expected %f, got %f",
-					stop.Id, expected.long, *stop.Longitude)
-			}
 		}
 	})
 
@@ -229,7 +279,7 @@ func TestFetchAndStoreGTFSRTFeed(t *testing.T) {
 		}
 
 		data := readFixture(t, "gtfs_rt_feed_vehicles.pb")
-		gtfsRT, err := obaGtfs.ParseRealtime(data, &obaGtfs.ParseRealtimeOptions{})
+		gtfsRT, err := remoteGtfs.ParseRealtime(data, &remoteGtfs.ParseRealtimeOptions{})
 		if err != nil {
 			t.Fatalf("Failed to parse GTFS-RT data: %v", err)
 		}
@@ -247,7 +297,7 @@ func TestFetchAndStoreGTFSRTFeed(t *testing.T) {
 			t.Fatalf("Expected %d vehicles, got %d", len(expectedRtData.Vehicles), len(realtimeData.Vehicles))
 		}
 
-		expectedMap := make(map[string]obaGtfs.Vehicle)
+		expectedMap := make(map[string]remoteGtfs.Vehicle)
 		for _, vehicle := range expectedRtData.Vehicles {
 			if vehicle.ID != nil {
 				expectedMap[vehicle.ID.ID] = vehicle

--- a/internal/gtfs/gtfs_service.go
+++ b/internal/gtfs/gtfs_service.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"time"
 
-	remoteGtfs "github.com/jamespfennell/gtfs"
+	obaGtfs "github.com/OneBusAway/go-gtfs"
 	"watchdog.onebusaway.org/internal/geo"
 	"watchdog.onebusaway.org/internal/models"
 )
@@ -39,11 +39,11 @@ func (gs *GtfsService) DownloadGTFSBundles(ctx context.Context, servers []models
 // but this public method can be used to download a single GTFS bundle.
 // It parses the GTFS data and stores it in the StaticStore using the serverID as the key.
 // It returns an error if the download or parsing fails.
-func (gs *GtfsService) DownloadGTFSBundle(ctx context.Context, url string, serverID int, maxRetires int) (*remoteGtfs.Static, error) {
+func (gs *GtfsService) DownloadGTFSBundle(ctx context.Context, url string, serverID int, maxRetires int) (*obaGtfs.Static, error) {
 	return downloadGTFSBundle(ctx, url, serverID, maxRetires)
 }
 
-func (gs *GtfsService) StoreGTFSBundle(staticBundle *remoteGtfs.Static, serverID int) error {
+func (gs *GtfsService) StoreGTFSBundle(staticBundle *obaGtfs.Static, serverID int) error {
 	return storeGTFSBundle(staticBundle, serverID, gs.StaticStore, gs.BoundingBoxStore)
 }
 
@@ -64,6 +64,6 @@ func GetEarliestAndLatestServiceDates(staticData *models.StaticData) (earliest, 
 	return earliestTime, latestTime, nil
 }
 
-func GetStopLocationsByIDs(serverID int, stopIDs []string, staticStore *StaticStore) (map[string]remoteGtfs.Stop, error) {
+func GetStopLocationsByIDs(serverID int, stopIDs []string, staticStore *StaticStore) (map[string]obaGtfs.Stop, error) {
 	return getStopLocationsByIDs(serverID, stopIDs, staticStore)
 }

--- a/internal/gtfs/gtfs_service.go
+++ b/internal/gtfs/gtfs_service.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"time"
 
-	obaGtfs "github.com/OneBusAway/go-gtfs"
+	remoteGtfs "github.com/OneBusAway/go-gtfs"
 	"watchdog.onebusaway.org/internal/geo"
 	"watchdog.onebusaway.org/internal/models"
 )
@@ -39,11 +39,11 @@ func (gs *GtfsService) DownloadGTFSBundles(ctx context.Context, servers []models
 // but this public method can be used to download a single GTFS bundle.
 // It parses the GTFS data and stores it in the StaticStore using the serverID as the key.
 // It returns an error if the download or parsing fails.
-func (gs *GtfsService) DownloadGTFSBundle(ctx context.Context, url string, serverID int, maxRetires int) (*obaGtfs.Static, error) {
+func (gs *GtfsService) DownloadGTFSBundle(ctx context.Context, url string, serverID int, maxRetires int) (*remoteGtfs.Static, error) {
 	return downloadGTFSBundle(ctx, url, serverID, maxRetires)
 }
 
-func (gs *GtfsService) StoreGTFSBundle(staticBundle *obaGtfs.Static, serverID int) error {
+func (gs *GtfsService) StoreGTFSBundle(staticBundle *remoteGtfs.Static, serverID int) error {
 	return storeGTFSBundle(staticBundle, serverID, gs.StaticStore, gs.BoundingBoxStore)
 }
 
@@ -64,6 +64,6 @@ func GetEarliestAndLatestServiceDates(staticData *models.StaticData) (earliest, 
 	return earliestTime, latestTime, nil
 }
 
-func GetStopLocationsByIDs(serverID int, stopIDs []string, staticStore *StaticStore) (map[string]obaGtfs.Stop, error) {
+func GetStopLocationsByIDs(serverID int, stopIDs []string, staticStore *StaticStore) (map[string]remoteGtfs.Stop, error) {
 	return getStopLocationsByIDs(serverID, stopIDs, staticStore)
 }

--- a/internal/gtfs/test_helpers.go
+++ b/internal/gtfs/test_helpers.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/OneBusAway/go-gtfs"
 )
 
 func setupGtfsServer(t *testing.T, fixturePath string) *httptest.Server {
@@ -54,4 +56,77 @@ func readFixture(t *testing.T, fixturePath string) []byte {
 	}
 
 	return data
+}
+
+func assertVehicle(t *testing.T, actual *gtfs.Vehicle, expected *gtfs.Vehicle) {
+	t.Helper()
+
+	if expected.ID != nil {
+		if actual.ID == nil {
+			t.Errorf("vehicle ID missing")
+		} else if expected.ID.ID != actual.ID.ID {
+			t.Errorf("vehicle ID mismatch: expected %s, got %s",
+				expected.ID.ID, actual.ID.ID)
+		}
+	}
+
+	if expected.StopID != nil {
+		if actual.StopID == nil {
+			t.Errorf("vehicle StopID missing")
+		} else if *expected.StopID != *actual.StopID {
+			t.Errorf("vehicle StopID mismatch: expected %s, got %s",
+				*expected.StopID, *actual.StopID)
+		}
+	}
+
+	if expected.CurrentStopSequence != nil {
+		if actual.CurrentStopSequence == nil {
+			t.Errorf("vehicle StopSequence missing")
+		} else if *expected.CurrentStopSequence != *actual.CurrentStopSequence {
+			t.Errorf("vehicle StopSequence mismatch: expected %d, got %d",
+				*expected.CurrentStopSequence, *actual.CurrentStopSequence)
+		}
+	}
+
+	if expected.Timestamp != nil {
+		if actual.Timestamp == nil {
+			t.Errorf("vehicle Timestamp missing")
+		} else if !expected.Timestamp.Equal(*actual.Timestamp) {
+			t.Errorf("vehicle Timestamp mismatch")
+		}
+	}
+
+	if expected.Position != nil {
+		if actual.Position == nil {
+			t.Errorf("vehicle Position missing")
+		} else {
+			const eps = 1e-5
+
+			if expected.Position.Latitude != nil && actual.Position.Latitude != nil {
+				if diff := *expected.Position.Latitude - *actual.Position.Latitude; diff > eps || diff < -eps {
+					t.Errorf("latitude mismatch: expected %f got %f",
+						*expected.Position.Latitude, *actual.Position.Latitude)
+				}
+			}
+
+			if expected.Position.Longitude != nil && actual.Position.Longitude != nil {
+				if diff := *expected.Position.Longitude - *actual.Position.Longitude; diff > eps || diff < -eps {
+					t.Errorf("longitude mismatch: expected %f got %f",
+						*expected.Position.Longitude, *actual.Position.Longitude)
+				}
+			}
+
+			if expected.Position.Speed != nil && actual.Position.Speed != nil {
+				if diff := *expected.Position.Speed - *actual.Position.Speed; diff > eps || diff < -eps {
+					t.Errorf("speed mismatch: expected %f got %f",
+						*expected.Position.Speed, *actual.Position.Speed)
+				}
+			}
+		}
+	}
+
+	if expected.IsEntityInMessage != actual.IsEntityInMessage {
+		t.Errorf("IsEntityInMessage mismatch: expected %v got %v",
+			expected.IsEntityInMessage, actual.IsEntityInMessage)
+	}
 }

--- a/internal/gtfs/test_helpers.go
+++ b/internal/gtfs/test_helpers.go
@@ -64,17 +64,17 @@ func assertPtr[T comparable](t *testing.T, expected *T, actual *T, field string,
 
 	if expected == nil {
 		if actual != nil {
-			t.Errorf("%s: unexpected value", field)
+			t.Errorf("%s mismatch:\nexpected: nil\ngot %v", field, *actual)
 		}
 		return
 	}
 
 	if actual == nil {
-		t.Errorf("%s: missing value", field)
+		t.Errorf("%s mismatch:\nexpected: %v\ngot nil", field, *expected)
 		return
 	}
 	if !equal(*expected, *actual) {
-		t.Errorf("%s mismatch: expected %v, got %v", field, *expected, *actual)
+		t.Errorf("%s mismatch:\nexpected %v, got %v", field, *expected, *actual)
 	}
 }
 
@@ -84,20 +84,19 @@ func assertVehicle(t *testing.T, actual *remoteGtfs.Vehicle, expected *remoteGtf
 		t.Fatal("expected vehicle must not be nil")
 	}
 	if actual == nil {
-		t.Errorf("actual vehicle is nil")
+		t.Errorf("vehicle mismatch:\nexpected: %v\ngot nil", expected)
 		return
 	}
 
 	if expected.ID == nil {
 		if actual.ID != nil {
-			t.Errorf("mismatch between expected vehicle ID and actual vehicle ID")
+			t.Errorf("vehicle ID mismatch:\nexpected: nil\ngot %v", actual.ID)
 		}
 	} else {
 		if actual.ID == nil {
-			t.Errorf("vehicle ID missing")
+			t.Errorf("vehicle ID mismatch:\nexpected: %v\ngot nil", expected.ID)
 		} else if expected.ID.ID != actual.ID.ID {
-			t.Errorf("vehicle ID mismatch: expected %s, got %s",
-				expected.ID.ID, actual.ID.ID)
+			t.Errorf("vehicle ID mismatch:\nexpected: %s\ngot %s", expected.ID.ID, actual.ID.ID)
 		}
 	}
 
@@ -113,11 +112,11 @@ func assertVehicle(t *testing.T, actual *remoteGtfs.Vehicle, expected *remoteGtf
 
 	if expected.Position == nil {
 		if actual.Position != nil {
-			t.Errorf("vehicle Position: unexpected value")
+			t.Errorf("vehicle Position mismatch:\nexpected: nil\ngot %v", actual.Position)
 		}
 	} else {
 		if actual.Position == nil {
-			t.Errorf("vehicle Position: missing value")
+			t.Errorf("vehicle Position mismatch:\nexpected: %v\ngot nil", expected.Position)
 		} else {
 			const eps = 1e-5
 
@@ -133,7 +132,7 @@ func assertVehicle(t *testing.T, actual *remoteGtfs.Vehicle, expected *remoteGtf
 	}
 
 	if expected.IsEntityInMessage != actual.IsEntityInMessage {
-		t.Errorf("IsEntityInMessage mismatch: expected %v got %v",
+		t.Errorf("IsEntityInMessage mismatch:\nexpected: %v\ngot %v",
 			expected.IsEntityInMessage, actual.IsEntityInMessage)
 	}
 }

--- a/internal/gtfs/test_helpers.go
+++ b/internal/gtfs/test_helpers.go
@@ -6,8 +6,9 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
-	"github.com/OneBusAway/go-gtfs"
+	remoteGtfs "github.com/OneBusAway/go-gtfs"
 )
 
 func setupGtfsServer(t *testing.T, fixturePath string) *httptest.Server {
@@ -58,7 +59,26 @@ func readFixture(t *testing.T, fixturePath string) []byte {
 	return data
 }
 
-func assertVehicle(t *testing.T, actual *gtfs.Vehicle, expected *gtfs.Vehicle) {
+func assertPtr[T comparable](t *testing.T, expected *T, actual *T, field string, equal func(a, b T) bool) {
+	t.Helper()
+
+	if expected == nil {
+		if actual != nil {
+			t.Errorf("%s: unexpected value", field)
+		}
+		return
+	}
+
+	if actual == nil {
+		t.Errorf("%s: missing value", field)
+		return
+	}
+	if !equal(*expected, *actual) {
+		t.Errorf("%s mismatch: expected %v, got %v", field, *expected, *actual)
+	}
+}
+
+func assertVehicle(t *testing.T, actual *remoteGtfs.Vehicle, expected *remoteGtfs.Vehicle) {
 	t.Helper()
 	if expected == nil {
 		t.Fatal("expected vehicle must not be nil")
@@ -68,7 +88,12 @@ func assertVehicle(t *testing.T, actual *gtfs.Vehicle, expected *gtfs.Vehicle) {
 		return
 
 	}
-	if expected.ID != nil {
+
+	if expected.ID == nil {
+		if actual.ID != nil {
+			t.Errorf("mismatch between expected vehicle ID and actual vehicle ID")
+		}
+	} else {
 		if actual.ID == nil {
 			t.Errorf("vehicle ID missing")
 		} else if expected.ID.ID != actual.ID.ID {
@@ -77,64 +102,34 @@ func assertVehicle(t *testing.T, actual *gtfs.Vehicle, expected *gtfs.Vehicle) {
 		}
 	}
 
-	if expected.StopID != nil {
-		if actual.StopID == nil {
-			t.Errorf("vehicle StopID missing")
-		} else if *expected.StopID != *actual.StopID {
-			t.Errorf("vehicle StopID mismatch: expected %s, got %s",
-				*expected.StopID, *actual.StopID)
-		}
-	}
+	assertPtr(t, expected.StopID, actual.StopID, "vehicle StopID", func(a, b string) bool {
+		return a == b
+	})
+	assertPtr(t, expected.CurrentStopSequence, actual.CurrentStopSequence, "vehicle StopSequence", func(a, b uint32) bool {
+		return a == b
+	})
+	assertPtr(t, expected.Timestamp, actual.Timestamp, "vehicle Timestamp", func(a, b time.Time) bool {
+		return a.Equal(b)
+	})
 
-	if expected.CurrentStopSequence != nil {
-		if actual.CurrentStopSequence == nil {
-			t.Errorf("vehicle StopSequence missing")
-		} else if *expected.CurrentStopSequence != *actual.CurrentStopSequence {
-			t.Errorf("vehicle StopSequence mismatch: expected %d, got %d",
-				*expected.CurrentStopSequence, *actual.CurrentStopSequence)
+	if expected.Position == nil {
+		if actual.Position != nil {
+			t.Errorf("vehicle Position: unexpected value")
 		}
-	}
-
-	if expected.Timestamp != nil {
-		if actual.Timestamp == nil {
-			t.Errorf("vehicle Timestamp missing")
-		} else if !expected.Timestamp.Equal(*actual.Timestamp) {
-			t.Errorf("vehicle Timestamp mismatch")
-		}
-	}
-
-	if expected.Position != nil {
+	} else {
 		if actual.Position == nil {
-			t.Errorf("vehicle Position missing")
+			t.Errorf("vehicle Position: missing value")
 		} else {
 			const eps = 1e-5
 
-			if expected.Position.Latitude != nil && actual.Position.Latitude != nil {
-				if diff := *expected.Position.Latitude - *actual.Position.Latitude; diff > eps || diff < -eps {
-					t.Errorf("latitude mismatch: expected %f got %f",
-						*expected.Position.Latitude, *actual.Position.Latitude)
-				}
-			} else if expected.Position.Latitude != nil && actual.Position.Latitude == nil {
-				t.Errorf("latitude missing")
+			floatEq := func(a, b float32) bool {
+				diff := a - b
+				return diff <= eps && diff >= -eps
 			}
 
-			if expected.Position.Longitude != nil && actual.Position.Longitude != nil {
-				if diff := *expected.Position.Longitude - *actual.Position.Longitude; diff > eps || diff < -eps {
-					t.Errorf("longitude mismatch: expected %f got %f",
-						*expected.Position.Longitude, *actual.Position.Longitude)
-				}
-			} else if expected.Position.Longitude != nil && actual.Position.Longitude == nil {
-				t.Errorf("longitude missing")
-			}
-
-			if expected.Position.Speed != nil && actual.Position.Speed != nil {
-				if diff := *expected.Position.Speed - *actual.Position.Speed; diff > eps || diff < -eps {
-					t.Errorf("speed mismatch: expected %f got %f",
-						*expected.Position.Speed, *actual.Position.Speed)
-				}
-			} else if expected.Position.Speed != nil && actual.Position.Speed == nil {
-				t.Errorf("speed missing")
-			}
+			assertPtr(t, expected.Position.Latitude, actual.Position.Latitude, "vehicle latitude", floatEq)
+			assertPtr(t, expected.Position.Longitude, actual.Position.Longitude, "vehicle longitude", floatEq)
+			assertPtr(t, expected.Position.Speed, actual.Position.Speed, "vehicle speed", floatEq)
 		}
 	}
 

--- a/internal/gtfs/test_helpers.go
+++ b/internal/gtfs/test_helpers.go
@@ -86,7 +86,6 @@ func assertVehicle(t *testing.T, actual *remoteGtfs.Vehicle, expected *remoteGtf
 	if actual == nil {
 		t.Errorf("actual vehicle is nil")
 		return
-
 	}
 
 	if expected.ID == nil {

--- a/internal/gtfs/test_helpers.go
+++ b/internal/gtfs/test_helpers.go
@@ -60,7 +60,14 @@ func readFixture(t *testing.T, fixturePath string) []byte {
 
 func assertVehicle(t *testing.T, actual *gtfs.Vehicle, expected *gtfs.Vehicle) {
 	t.Helper()
+	if expected == nil {
+		t.Fatal("expected vehicle must not be nil")
+	}
+	if actual == nil {
+		t.Errorf("actual vehicle is nil")
+		return
 
+	}
 	if expected.ID != nil {
 		if actual.ID == nil {
 			t.Errorf("vehicle ID missing")
@@ -107,6 +114,8 @@ func assertVehicle(t *testing.T, actual *gtfs.Vehicle, expected *gtfs.Vehicle) {
 					t.Errorf("latitude mismatch: expected %f got %f",
 						*expected.Position.Latitude, *actual.Position.Latitude)
 				}
+			} else if expected.Position.Latitude != nil && actual.Position.Latitude == nil {
+				t.Errorf("latitude missing")
 			}
 
 			if expected.Position.Longitude != nil && actual.Position.Longitude != nil {
@@ -114,6 +123,8 @@ func assertVehicle(t *testing.T, actual *gtfs.Vehicle, expected *gtfs.Vehicle) {
 					t.Errorf("longitude mismatch: expected %f got %f",
 						*expected.Position.Longitude, *actual.Position.Longitude)
 				}
+			} else if expected.Position.Longitude != nil && actual.Position.Longitude == nil {
+				t.Errorf("longitude missing")
 			}
 
 			if expected.Position.Speed != nil && actual.Position.Speed != nil {
@@ -121,6 +132,8 @@ func assertVehicle(t *testing.T, actual *gtfs.Vehicle, expected *gtfs.Vehicle) {
 					t.Errorf("speed mismatch: expected %f got %f",
 						*expected.Position.Speed, *actual.Position.Speed)
 				}
+			} else if expected.Position.Speed != nil && actual.Position.Speed == nil {
+				t.Errorf("speed missing")
 			}
 		}
 	}

--- a/internal/metrics/agencies_with_coverage_test.go
+++ b/internal/metrics/agencies_with_coverage_test.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"testing"
 
-	obaGtfs "github.com/OneBusAway/go-gtfs"
+	remoteGtfs "github.com/OneBusAway/go-gtfs"
 	"watchdog.onebusaway.org/internal/gtfs"
 	"watchdog.onebusaway.org/internal/models"
 )
@@ -23,7 +23,7 @@ func TestCheckAgenciesWithCoverage(t *testing.T) {
 		testServer := createTestServer(ts.URL, "Test Server", 999, "test-key", "http://example.com", "test-api-value", "test-api-key", "1")
 
 		data := readFixture(t, "gtfs.zip")
-		staticBundle, err := obaGtfs.ParseStatic(data, obaGtfs.ParseStaticOptions{})
+		staticBundle, err := remoteGtfs.ParseStatic(data, remoteGtfs.ParseStaticOptions{})
 		if err != nil {
 			t.Fatal("failed to parse gtfs static data")
 		}

--- a/internal/metrics/agencies_with_coverage_test.go
+++ b/internal/metrics/agencies_with_coverage_test.go
@@ -6,8 +6,7 @@ import (
 	"os"
 	"testing"
 
-	remoteGtfs "github.com/jamespfennell/gtfs"
-
+	obaGtfs "github.com/OneBusAway/go-gtfs"
 	"watchdog.onebusaway.org/internal/gtfs"
 	"watchdog.onebusaway.org/internal/models"
 )
@@ -24,7 +23,7 @@ func TestCheckAgenciesWithCoverage(t *testing.T) {
 		testServer := createTestServer(ts.URL, "Test Server", 999, "test-key", "http://example.com", "test-api-value", "test-api-key", "1")
 
 		data := readFixture(t, "gtfs.zip")
-		staticBundle, err := remoteGtfs.ParseStatic(data, remoteGtfs.ParseStaticOptions{})
+		staticBundle, err := obaGtfs.ParseStatic(data, obaGtfs.ParseStaticOptions{})
 		if err != nil {
 			t.Fatal("failed to parse gtfs static data")
 		}

--- a/internal/metrics/bundle_expiration_test.go
+++ b/internal/metrics/bundle_expiration_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	remoteGtfs "github.com/jamespfennell/gtfs"
+	obaGtfs "github.com/OneBusAway/go-gtfs"
 	"watchdog.onebusaway.org/internal/gtfs"
 	"watchdog.onebusaway.org/internal/models"
 )
@@ -13,7 +13,7 @@ func TestCheckBundleExpiration(t *testing.T) {
 	testServer := createTestServer("www.example.com", "Test Server", 999, "", "www.example.com", "test-api-value", "test-api-key", "1")
 
 	data := readFixture(t, "gtfs.zip")
-	staticBundle, err := remoteGtfs.ParseStatic(data, remoteGtfs.ParseStaticOptions{})
+	staticBundle, err := obaGtfs.ParseStatic(data, obaGtfs.ParseStaticOptions{})
 	if err != nil {
 		t.Fatal("failed to parse gtfs static data")
 	}

--- a/internal/metrics/bundle_expiration_test.go
+++ b/internal/metrics/bundle_expiration_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	obaGtfs "github.com/OneBusAway/go-gtfs"
+	remoteGtfs "github.com/OneBusAway/go-gtfs"
 	"watchdog.onebusaway.org/internal/gtfs"
 	"watchdog.onebusaway.org/internal/models"
 )
@@ -13,7 +13,7 @@ func TestCheckBundleExpiration(t *testing.T) {
 	testServer := createTestServer("www.example.com", "Test Server", 999, "", "www.example.com", "test-api-value", "test-api-key", "1")
 
 	data := readFixture(t, "gtfs.zip")
-	staticBundle, err := obaGtfs.ParseStatic(data, obaGtfs.ParseStaticOptions{})
+	staticBundle, err := remoteGtfs.ParseStatic(data, remoteGtfs.ParseStaticOptions{})
 	if err != nil {
 		t.Fatal("failed to parse gtfs static data")
 	}

--- a/internal/metrics/oba_rest_api_metrics_test.go
+++ b/internal/metrics/oba_rest_api_metrics_test.go
@@ -1,7 +1,7 @@
 package metrics
 
 import (
-	obaGtfs "github.com/OneBusAway/go-gtfs"
+	remoteGtfs "github.com/OneBusAway/go-gtfs"
 	"gopkg.in/dnaeon/go-vcr.v4/pkg/recorder"
 	"net/http"
 	"path/filepath"
@@ -13,7 +13,7 @@ import (
 
 func TestFetchObaAPIMetrics_WithVCR(t *testing.T) {
 	data := readFixture(t, "gtfs.zip")
-	staticBundle, err := obaGtfs.ParseStatic(data, obaGtfs.ParseStaticOptions{})
+	staticBundle, err := remoteGtfs.ParseStatic(data, remoteGtfs.ParseStaticOptions{})
 	staticData := models.NewStaticData(staticBundle)
 	if err != nil {
 		t.Fatal("failed to parse gtfs static data")

--- a/internal/metrics/oba_rest_api_metrics_test.go
+++ b/internal/metrics/oba_rest_api_metrics_test.go
@@ -1,20 +1,19 @@
 package metrics
 
 import (
+	obaGtfs "github.com/OneBusAway/go-gtfs"
+	"gopkg.in/dnaeon/go-vcr.v4/pkg/recorder"
 	"net/http"
 	"path/filepath"
 	"testing"
 	"time"
-
-	remoteGtfs "github.com/jamespfennell/gtfs"
-	"gopkg.in/dnaeon/go-vcr.v4/pkg/recorder"
 	"watchdog.onebusaway.org/internal/gtfs"
 	"watchdog.onebusaway.org/internal/models"
 )
 
 func TestFetchObaAPIMetrics_WithVCR(t *testing.T) {
 	data := readFixture(t, "gtfs.zip")
-	staticBundle, err := remoteGtfs.ParseStatic(data, remoteGtfs.ParseStaticOptions{})
+	staticBundle, err := obaGtfs.ParseStatic(data, obaGtfs.ParseStaticOptions{})
 	staticData := models.NewStaticData(staticBundle)
 	if err != nil {
 		t.Fatal("failed to parse gtfs static data")

--- a/internal/metrics/stop_clusters.go
+++ b/internal/metrics/stop_clusters.go
@@ -1,7 +1,7 @@
 package metrics
 
 import (
-	obaGtfs "github.com/OneBusAway/go-gtfs"
+	remoteGtfs "github.com/OneBusAway/go-gtfs"
 	"watchdog.onebusaway.org/internal/geo"
 )
 
@@ -19,7 +19,7 @@ import (
 // - slugID: a unique identifier for the server or deployment instance
 // - agencyID: the GTFS agency identifier
 // - unmatchedStops: a map of stop IDs to GTFS stop objects not matched to gtfs static data
-func reportUnmatchedStopClusters(slugID, agencyID string, unmatchedStops map[string]obaGtfs.Stop) {
+func reportUnmatchedStopClusters(slugID, agencyID string, unmatchedStops map[string]remoteGtfs.Stop) {
 	clusterCount := make(map[string]int)
 	clusterType := make(map[string]string) // station or s2
 

--- a/internal/metrics/stop_clusters.go
+++ b/internal/metrics/stop_clusters.go
@@ -1,7 +1,7 @@
 package metrics
 
 import (
-	remoteGtfs "github.com/jamespfennell/gtfs"
+	obaGtfs "github.com/OneBusAway/go-gtfs"
 	"watchdog.onebusaway.org/internal/geo"
 )
 
@@ -19,7 +19,7 @@ import (
 // - slugID: a unique identifier for the server or deployment instance
 // - agencyID: the GTFS agency identifier
 // - unmatchedStops: a map of stop IDs to GTFS stop objects not matched to gtfs static data
-func reportUnmatchedStopClusters(slugID, agencyID string, unmatchedStops map[string]remoteGtfs.Stop) {
+func reportUnmatchedStopClusters(slugID, agencyID string, unmatchedStops map[string]obaGtfs.Stop) {
 	clusterCount := make(map[string]int)
 	clusterType := make(map[string]string) // station or s2
 

--- a/internal/metrics/vehicle_metrics_test.go
+++ b/internal/metrics/vehicle_metrics_test.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	remoteGtfs "github.com/jamespfennell/gtfs"
+	obaGtfs "github.com/OneBusAway/go-gtfs"
 	"watchdog.onebusaway.org/internal/geo"
 	"watchdog.onebusaway.org/internal/gtfs"
 	"watchdog.onebusaway.org/internal/models"
@@ -30,7 +30,7 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
-	gtfsRT, err := remoteGtfs.ParseRealtime(data, &remoteGtfs.ParseRealtimeOptions{})
+	gtfsRT, err := obaGtfs.ParseRealtime(data, &obaGtfs.ParseRealtimeOptions{})
 	if err != nil {
 		fmt.Printf("Failed to parse GTFS-RT data: %v\n", err)
 		os.Exit(1)

--- a/internal/metrics/vehicle_metrics_test.go
+++ b/internal/metrics/vehicle_metrics_test.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	obaGtfs "github.com/OneBusAway/go-gtfs"
+	remoteGtfs "github.com/OneBusAway/go-gtfs"
 	"watchdog.onebusaway.org/internal/geo"
 	"watchdog.onebusaway.org/internal/gtfs"
 	"watchdog.onebusaway.org/internal/models"
@@ -30,7 +30,7 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
-	gtfsRT, err := obaGtfs.ParseRealtime(data, &obaGtfs.ParseRealtimeOptions{})
+	gtfsRT, err := remoteGtfs.ParseRealtime(data, &remoteGtfs.ParseRealtimeOptions{})
 	if err != nil {
 		fmt.Printf("Failed to parse GTFS-RT data: %v\n", err)
 		os.Exit(1)

--- a/internal/models/gtfs_models.go
+++ b/internal/models/gtfs_models.go
@@ -1,7 +1,7 @@
 package models
 
 import (
-	obaGtfs "github.com/OneBusAway/go-gtfs"
+	remoteGtfs "github.com/OneBusAway/go-gtfs"
 )
 
 // StaticData represents the static GTFS data structure.
@@ -13,16 +13,16 @@ import (
 // to include more fields from the GTFS Static bundle.
 // Don't forget to include them here
 type StaticData struct {
-	Stops    []obaGtfs.Stop
-	Agencies []obaGtfs.Agency
-	Services []obaGtfs.Service
+	Stops    []remoteGtfs.Stop
+	Agencies []remoteGtfs.Agency
+	Services []remoteGtfs.Service
 }
 
-func NewStaticData(GtfsStaticBundle *obaGtfs.Static) *StaticData {
+func NewStaticData(GtfsStaticBundle *remoteGtfs.Static) *StaticData {
 	return &StaticData{
-		Stops:    append([]obaGtfs.Stop(nil), GtfsStaticBundle.Stops...),
-		Agencies: append([]obaGtfs.Agency(nil), GtfsStaticBundle.Agencies...),
-		Services: append([]obaGtfs.Service(nil), GtfsStaticBundle.Services...),
+		Stops:    append([]remoteGtfs.Stop(nil), GtfsStaticBundle.Stops...),
+		Agencies: append([]remoteGtfs.Agency(nil), GtfsStaticBundle.Agencies...),
+		Services: append([]remoteGtfs.Service(nil), GtfsStaticBundle.Services...),
 	}
 }
 
@@ -34,11 +34,11 @@ func NewStaticData(GtfsStaticBundle *obaGtfs.Static) *StaticData {
 // to include more fields from the GTFS Realtime bundle.
 // Don't forget to include them here
 type RealtimeData struct {
-	Vehicles []obaGtfs.Vehicle
+	Vehicles []remoteGtfs.Vehicle
 }
 
-func NewRealtimeData(GtfsRealtimeBundle *obaGtfs.Realtime) *RealtimeData {
+func NewRealtimeData(GtfsRealtimeBundle *remoteGtfs.Realtime) *RealtimeData {
 	return &RealtimeData{
-		Vehicles: append([]obaGtfs.Vehicle(nil), GtfsRealtimeBundle.Vehicles...),
+		Vehicles: append([]remoteGtfs.Vehicle(nil), GtfsRealtimeBundle.Vehicles...),
 	}
 }

--- a/internal/models/gtfs_models.go
+++ b/internal/models/gtfs_models.go
@@ -1,7 +1,7 @@
 package models
 
 import (
-	remoteGtfs "github.com/jamespfennell/gtfs"
+	obaGtfs "github.com/OneBusAway/go-gtfs"
 )
 
 // StaticData represents the static GTFS data structure.
@@ -13,16 +13,16 @@ import (
 // to include more fields from the GTFS Static bundle.
 // Don't forget to include them here
 type StaticData struct {
-	Stops    []remoteGtfs.Stop
-	Agencies []remoteGtfs.Agency
-	Services []remoteGtfs.Service
+	Stops    []obaGtfs.Stop
+	Agencies []obaGtfs.Agency
+	Services []obaGtfs.Service
 }
 
-func NewStaticData(GtfsStaticBundle *remoteGtfs.Static) *StaticData {
+func NewStaticData(GtfsStaticBundle *obaGtfs.Static) *StaticData {
 	return &StaticData{
-		Stops:    append([]remoteGtfs.Stop(nil), GtfsStaticBundle.Stops...),
-		Agencies: append([]remoteGtfs.Agency(nil), GtfsStaticBundle.Agencies...),
-		Services: append([]remoteGtfs.Service(nil), GtfsStaticBundle.Services...),
+		Stops:    append([]obaGtfs.Stop(nil), GtfsStaticBundle.Stops...),
+		Agencies: append([]obaGtfs.Agency(nil), GtfsStaticBundle.Agencies...),
+		Services: append([]obaGtfs.Service(nil), GtfsStaticBundle.Services...),
 	}
 }
 
@@ -34,11 +34,11 @@ func NewStaticData(GtfsStaticBundle *remoteGtfs.Static) *StaticData {
 // to include more fields from the GTFS Realtime bundle.
 // Don't forget to include them here
 type RealtimeData struct {
-	Vehicles []remoteGtfs.Vehicle
+	Vehicles []obaGtfs.Vehicle
 }
 
-func NewRealtimeData(GtfsRealtimeBundle *remoteGtfs.Realtime) *RealtimeData {
+func NewRealtimeData(GtfsRealtimeBundle *obaGtfs.Realtime) *RealtimeData {
 	return &RealtimeData{
-		Vehicles: append([]remoteGtfs.Vehicle(nil), GtfsRealtimeBundle.Vehicles...),
+		Vehicles: append([]obaGtfs.Vehicle(nil), GtfsRealtimeBundle.Vehicles...),
 	}
 }


### PR DESCRIPTION
closes #92 

for the gtfs tests i did the following:

currently watchdog monitors `stops`, `agencies` for static data and `vehiclePosition` for gtfs rt 

i covered these fields for agencies since they are required [here](https://gtfs.org/documentation/schedule/reference/#agencytxt): 
* `agency_name`
* `agency_url`
* `agency_timezone`
* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * 

for stops i covered:
* `stop_name`
* `stop_lat`
*  `stop_lon`

I compared the result based on some of the data that already exist in the gtfs test
* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * 

i wrote an assert helper function that asserts all fields a vehicle has


note: watchdog also uses `calendar.txt` file data but it uses it as a work around to get the earliest and latest service end dates, I didn't find any tests written related to it should I write unit tests for these as well ? 

@0xaboomar take a look and let me know what else might be needed/changed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched the internal GTFS library to a compatible alternative for static and realtime feed processing.

* **Tests**
  * Updated and expanded tests and test helpers to validate compatibility with the new GTFS library, adding stronger assertions for agencies, stops, vehicles, positions, timestamps, and realtime parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->