### PR TITLE
Remove Unmatched Stop Locations metric from dashboard scope

### DIFF
--- a/grafana/dashboards/watchdog_metrics_dashboard.json
+++ b/grafana/dashboards/watchdog_metrics_dashboard.json
@@ -534,30 +534,6 @@
       ],
       "title": "6.1 Unmatched Stop Clusters",
       "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "name": "Prometheus"
-      },
-      "description": "Metrics: oba_unmatched_stop_location\nQuestion answered: \"Which exact stops are failing?\"",
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 54
-      },
-      "id": 602,
-      "targets": [
-        {
-          "expr": "oba_unmatched_stop_location",
-          "refId": "A",
-          "datasource": {
-            "name": "Prometheus"
-          }
-        }
-      ],
-      "title": "6.2 Unmatched Stop Locations",
-      "type": "timeseries"
     }
   ],
   "schemaVersion": 39,


### PR DESCRIPTION
Removes the Unmatched Stop Locations visualization in preparation for surfacing this data through dedicated investigation and drill-down workflows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Removed a metric panel from the Watchdog Metrics Dashboard for improved dashboard clarity and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->