### PR TITLE
feat(ui): enhance api status pannel

### DIFF
--- a/grafana/dashboards/watchdog_metrics_dashboard.json
+++ b/grafana/dashboards/watchdog_metrics_dashboard.json
@@ -38,9 +38,55 @@
     },
     {
       "datasource": {
-        "name": "Prometheus"
+        "type": "prometheus"
       },
       "description": "Metrics: oba_api_status\nQuestion answered: \"Is the API up?\"",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "fillOpacity": 70,
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineWidth": 1,
+            "spanNulls": false
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "red",
+                  "index": 1,
+                  "text": "DOWN"
+                },
+                "1": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "UP"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
       "gridPos": {
         "h": 8,
         "w": 12,
@@ -48,17 +94,41 @@
         "y": 1
       },
       "id": 101,
+      "options": {
+        "alignValue": "center",
+        "annotations": {
+          "clustering": -1,
+          "multiLane": false
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "mergeValues": true,
+        "rowHeight": 0.85,
+        "showValue": "auto",
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "13.0.2",
       "targets": [
         {
-          "expr": "oba_api_status{server_id=~\"$server_id\"}",
-          "refId": "A",
           "datasource": {
-            "name": "Prometheus"
-          }
+            "type": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "oba_api_status{server_id=~\"$server_id\"}",
+          "legendFormat": "Server {{server_id}}",
+          "range": true,
+          "refId": "A"
         }
       ],
       "title": "1.1 API Status",
-      "type": "timeseries"
+      "type": "state-timeline"
     },
     {
       "datasource": {


### PR DESCRIPTION
closes #96 

I used the [State timeline](https://grafana.com/docs/grafana/latest/visualizations/panels-visualizations/visualizations/state-timeline/) visualization type since `oba_api_status` metric has either 1 or 0, I mapped the values to Up, Down 

here is a quick view of how it looks with 2 local servers:
<img width="728" height="317" alt="image" src="https://github.com/user-attachments/assets/1baf181b-9bec-4ea7-8ca2-b72ebc9135c6" />

@0xaboomar let me know if something else is needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the API Status dashboard panel with an enhanced state-timeline visualization for improved status tracking
  * Added color-coded status indicators (green for UP, red for DOWN) for better visual clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->