### PR TITLE
fix(config): validate OBA server configs and drop invalid entries

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,60 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+Watchdog is a Go service that monitors [OneBusAway](https://onebusaway.org/) (OBA) REST API servers and their GTFS feeds, exposing the results as Prometheus metrics. It polls every configured OBA server on a fixed interval, validates static GTFS, GTFS-RT, and OBA API responses, and updates gauges/counters that Prometheus scrapes and Grafana visualizes. See `docs/METRICS.md` for the full metric catalog and interpretation guide.
+
+## Commands
+
+```bash
+make test          # go test ./...   (unit tests; same as CI minus coverage)
+make vet           # go vet ./...
+make fmt           # gofmt -w .  (run before committing)
+make compile       # CGO_ENABLED=0 go build -v -o . ./...
+
+go test ./internal/metrics/...                          # single package
+go test -run TestCheckBundleExpiration ./internal/metrics/   # single test
+
+# Integration tests are gated behind a build tag and need a real config:
+go test -tags=integration ./internal/integration/ -integration-config path/to/integration_config.json
+```
+
+CI (`.github/workflows/ci.yml`) runs `go test -v -coverprofile=profile.cov ./...` and uploads to Coveralls. Integration tests are NOT run in CI — they require live OBA/GTFS endpoints.
+
+Running locally requires a `config.json` (git-ignored). Copy `config.json.template`, fill it in, then:
+```bash
+go run ./cmd/watchdog/ --config-file config.json
+```
+Or run the full stack (Watchdog :4000, Prometheus :9090, Grafana :3000) with `docker compose up --build`.
+
+## Architecture
+
+**Dependency wiring happens in one place.** `app.New()` (`internal/app/app.go`) constructs every store and service and injects them. `cmd/watchdog/main.go` is the only `main`: it parses flags, loads config, builds the `Application`, kicks off the background goroutines, and starts the HTTP server. When adding a service or store, wire it through `app.New()` rather than constructing it ad hoc — constructor injection is what makes the metric functions testable.
+
+**Service / store separation.** Each domain package (`config`, `gtfs`, `geo`, `metrics`) exposes a `*Service` struct holding injected dependencies (logger, HTTP client, stores). The Service methods are thin wrappers that delegate to lowercase package-private functions (e.g. `MetricsService.CheckBundleExpiration` → `checkBundleExpiration`). The private functions take their dependencies as explicit args, so tests call them directly without building a full Service. Follow this pattern: exported method on the Service for production wiring, private function with explicit params for the logic.
+
+**Stores are the shared state.** In-memory, `sync.RWMutex`-guarded caches passed by pointer so multiple services see the same data:
+- `gtfs.StaticStore` — parsed GTFS static bundles, keyed by server ID.
+- `gtfs.RealtimeStore` — most recent parsed GTFS-RT feed.
+- `geo.BoundingBoxStore` — per-server geographic bounds (used to flag out-of-bounds vehicles).
+- `metrics.VehicleLastSeen` — last-seen timestamps for telemetry/reporting-interval metrics; self-prunes via a `ClearRoutine` goroutine.
+- `config.BackoffStore` — per-server exponential backoff state.
+
+**Background goroutines** (started from `main.go`): periodic metrics collection, 24h GTFS bundle refresh, vehicle last-seen cleanup, and (only with `--config-url`) a config refresh loop. All take the root `context.Context` and exit cleanly on cancel.
+
+**The collection loop is the heart of the system.** `StartMetricsCollection` (`internal/app/metrics_collector.go`) ticks every `--fetch-interval` seconds and calls `CollectMetricsForServer` for each server. That function runs probes in a deliberate order; read its doc comment before changing it. Two ordering constraints matter:
+- **Backoff is non-blocking and lives in `BackoffStore`** — not a `time.Sleep`. Before each cycle it checks `NextRetryAt`; if a server is still backing off, its entire collection is skipped this tick. A failed ping grows the backoff; a success resets it. This is intentional so backoff never exceeds the fetch interval and goroutines never overlap per server. Do not replace it with a blocking retry.
+- **`FetchAndStoreGTFSRTFeed` is a hard gate.** Every check after it (`CheckVehicleCountMatch`, `TrackVehicleTelemetry`, `TrackInvalidVehiclesAndStoppedOutOfBounds`) reads the realtime store, so if the RT fetch fails the function returns early. Earlier checks each log-and-continue on error.
+
+**Metrics are global `promauto` vectors** declared in `internal/metrics/metrics.go` and registered with the default registry at package init. Metric functions look up data from the stores and `.WithLabelValues(...).Set(...)`. Common label keys: `server_id`, `agency_id`, `server_url`, `vehicle_id`. `/metrics` is served through a caching handler (`middleware.NewCachedPromHandler`, 10s) to limit scrape cost.
+
+**Error reporting goes through `internal/report`** (Sentry wrapper). Collection code logs via the injected `slog.Logger` AND calls `report.ReportErrorWithSentryOptions` with `server_id`/`server_name` tags so failures are correlated per server. Match this dual logging when adding collection steps.
+
+**Config** can come from a local file (`--config-file`) or a remote URL (`--config-url`, optionally Basic-Auth'd via `CONFIG_AUTH_USER`/`CONFIG_AUTH_PASS`). Exactly one source is required (`config.ValidateConfigFlags`). A config is a JSON array of `models.ObaServer` objects.
+
+## Testing notes
+
+- Unit tests use `httptest` servers and fixtures under `testdata/`; the metrics package uses `go-vcr` cassettes (`internal/metrics/testdata/vcr/*.yaml`) to replay recorded OBA API responses. Each package has a `test_helpers.go` with constructors like `createTestServer`.
+- Because metrics are global vars, tests that assert on them should reset/inspect via the prometheus client model rather than assuming a clean registry.

--- a/cmd/watchdog/main.go
+++ b/cmd/watchdog/main.go
@@ -72,6 +72,17 @@ func main() {
 	// Using a pooled client allows for better performance and resource management.
 	client := app.NewPooledClient()
 
+	// Initialize Sentry for error reporting before anything else that might
+	// report an error. Configuration loading (below) validates servers and
+	// reports invalid ones to Sentry, so Sentry must be live first — otherwise
+	// those startup reports are captured by an uninitialized hub and lost.
+	//
+	// Note: you should have (SENTRY_DSN) environment variable set to your Sentry DSN.
+	// Link to official documentation: https://docs.sentry.io/concepts/key-terms/dsn-explainer/
+	report.SetupSentry()
+	defer report.FlushSentry()
+	report.ConfigureScope(cfg.Env, version)
+
 	// Load the configuration from the specified source
 	// If a config file is specified, load it from disk.
 	// If a config URL is specified, fetch it over HTTP(S).
@@ -103,18 +114,6 @@ func main() {
 	// this New() function is critical in understanding how we structure the application take a look at it.
 	// and also take a look at service file in each package to see the dependencies and the exposed methods and function.
 	app := app.New(&cfg, logger, client, version)
-
-	// Initialize Sentry for error reporting
-	// This will allow us to capture and report errors that occur during the application's execution.
-	// Sentry is a powerful error tracking tool that helps developers monitor and fix crashes in real-time.
-	// It provides detailed error reports, stack traces, and context about the errors.
-	//
-	// Note: you should have (SENTRY_DSN) environment variable set to your Sentry DSN.
-	// you can read in sentry documentation how to set it up.
-	// Link to official documentation: https://docs.sentry.io/concepts/key-terms/dsn-explainer/
-	report.SetupSentry()
-	defer report.FlushSentry()
-	report.ConfigureScope(cfg.Env, version)
 
 	// From here we set up all dependencies and we are ready to start business logic.
 

--- a/internal/config/config_loader.go
+++ b/internal/config/config_loader.go
@@ -114,7 +114,7 @@ func loadConfigFromFile(filePath string) ([]models.ObaServer, error) {
 		return nil, fmt.Errorf("failed to unmarshal JSON: %v", err)
 	}
 
-	return servers, nil
+	return filterValidServers(servers), nil
 }
 
 // loadConfigFromURL fetches a JSON configuration from a remote HTTP(S) endpoint,
@@ -180,5 +180,5 @@ func loadConfigFromURL(ctx context.Context, client *http.Client, url, authUser, 
 		return nil, fmt.Errorf("failed to unmarshal JSON: %v", err)
 	}
 
-	return servers, nil
+	return filterValidServers(servers), nil
 }

--- a/internal/config/config_loader_test.go
+++ b/internal/config/config_loader_test.go
@@ -28,7 +28,8 @@ func TestLoadConfigFromFile(t *testing.T) {
 		"trip_update_url": "https://trip.example.com",
 		"vehicle_position_url": "https://vehicle.example.com",
 		"gtfs_rt_api_key": "",
-		"gtfs_rt_api_value": ""
+		"gtfs_rt_api_value": "",
+		"agency_id": "agency-1"
 		}]`
 
 		dir := t.TempDir()
@@ -56,6 +57,7 @@ func TestLoadConfigFromFile(t *testing.T) {
 			VehiclePositionUrl: "https://vehicle.example.com",
 			GtfsRtApiKey:       "",
 			GtfsRtApiValue:     "",
+			AgencyID:           "agency-1",
 		}
 
 		if servers[0] != expected {
@@ -102,7 +104,8 @@ func TestLoadConfigFromURL(t *testing.T) {
 			 "trip_update_url": "https://trip.example.com",
 			 "vehicle_position_url": "https://vehicle.example.com",
 			 "gtfs_rt_api_key": "",
-			 "gtfs_rt_api_value": ""
+			 "gtfs_rt_api_value": "",
+			 "agency_id": "agency-1"
 			}]`))
 		}))
 		defer ts.Close()
@@ -124,6 +127,7 @@ func TestLoadConfigFromURL(t *testing.T) {
 			GtfsUrl:            "https://gtfs.example.com",
 			TripUpdateUrl:      "https://trip.example.com",
 			VehiclePositionUrl: "https://vehicle.example.com",
+			AgencyID:           "agency-1",
 		}
 
 		if servers[0] != expected {
@@ -310,9 +314,11 @@ func TestRefreshConfig(t *testing.T) {
 					{
 							"id": 999,
 							"name": "Refreshed Test Server",
-							"url": "https://refreshed.example.com",
-							"api_key": "refreshed-key",
-							"gtfs_url": "https://refreshed.example.com/gtfs.zip"
+							"oba_base_url": "https://refreshed.example.com",
+							"oba_api_key": "refreshed-key",
+							"gtfs_url": "https://refreshed.example.com/gtfs.zip",
+							"vehicle_position_url": "https://refreshed.example.com/vehicles",
+							"agency_id": "agency-999"
 					}
 			]`)
 	}))

--- a/internal/config/config_validation.go
+++ b/internal/config/config_validation.go
@@ -1,0 +1,73 @@
+package config
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/getsentry/sentry-go"
+	"watchdog.onebusaway.org/internal/models"
+	"watchdog.onebusaway.org/internal/report"
+)
+
+// ValidateServer checks that an ObaServer has all the fields Watchdog requires
+// to monitor it. A common production failure mode is a service-discovery file
+// that emits JSON null for feed URLs; null unmarshals to the empty string, which
+// then produces cryptic `unsupported protocol scheme ""` errors on every fetch
+// cycle. Validating up front turns that into a single actionable error.
+//
+// The GTFS-RT auth header pair (gtfs_rt_api_key / gtfs_rt_api_value) and
+// trip_update_url are intentionally optional and not validated here.
+//
+// It returns an error naming every missing field, or nil if the server is valid.
+func ValidateServer(server models.ObaServer) error {
+	var missing []string
+
+	if server.ID == 0 {
+		missing = append(missing, "id")
+	}
+
+	requiredStrings := []struct {
+		name  string
+		value string
+	}{
+		{"name", server.Name},
+		{"oba_base_url", server.ObaBaseURL},
+		{"oba_api_key", server.ObaApiKey},
+		{"gtfs_url", server.GtfsUrl},
+		{"vehicle_position_url", server.VehiclePositionUrl},
+		{"agency_id", server.AgencyID},
+	}
+	for _, field := range requiredStrings {
+		if strings.TrimSpace(field.value) == "" {
+			missing = append(missing, field.name)
+		}
+	}
+
+	if len(missing) > 0 {
+		return fmt.Errorf("server %q (id %d) is missing required fields: %s",
+			server.Name, server.ID, strings.Join(missing, ", "))
+	}
+	return nil
+}
+
+// filterValidServers returns only the servers that pass ValidateServer. Each
+// invalid server is reported to Sentry and dropped so that one misconfigured
+// entry (e.g. null feed URLs) cannot block monitoring of the rest of the fleet.
+func filterValidServers(servers []models.ObaServer) []models.ObaServer {
+	valid := make([]models.ObaServer, 0, len(servers))
+	for _, server := range servers {
+		if err := ValidateServer(server); err != nil {
+			report.ReportErrorWithSentryOptions(err, report.SentryReportOptions{
+				Tags: map[string]string{
+					"server_id":   strconv.Itoa(server.ID),
+					"server_name": server.Name,
+				},
+				Level: sentry.LevelError,
+			})
+			continue
+		}
+		valid = append(valid, server)
+	}
+	return valid
+}

--- a/internal/config/config_validation_test.go
+++ b/internal/config/config_validation_test.go
@@ -163,7 +163,9 @@ func TestLoadConfigFromURLFiltersInvalidServers(t *testing.T) {
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(body))
+		if _, err := w.Write([]byte(body)); err != nil {
+			t.Errorf("failed to write response: %v", err)
+		}
 	}))
 	defer ts.Close()
 

--- a/internal/config/config_validation_test.go
+++ b/internal/config/config_validation_test.go
@@ -1,0 +1,219 @@
+package config
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"watchdog.onebusaway.org/internal/models"
+)
+
+// validServer returns a fully-populated server that should pass validation.
+func validServer() models.ObaServer {
+	return models.ObaServer{
+		Name:               "Test Server",
+		ID:                 1,
+		ObaBaseURL:         "https://test.example.com",
+		ObaApiKey:          "test-key",
+		GtfsUrl:            "https://gtfs.example.com",
+		TripUpdateUrl:      "https://trip.example.com",
+		VehiclePositionUrl: "https://vehicle.example.com",
+		GtfsRtApiKey:       "",
+		GtfsRtApiValue:     "",
+		AgencyID:           "agency-1",
+	}
+}
+
+func TestValidateServer(t *testing.T) {
+	t.Run("valid server passes", func(t *testing.T) {
+		if err := ValidateServer(validServer()); err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+	})
+
+	t.Run("empty optional GTFS-RT auth fields are allowed", func(t *testing.T) {
+		s := validServer()
+		s.GtfsRtApiKey = ""
+		s.GtfsRtApiValue = ""
+		s.TripUpdateUrl = ""
+		if err := ValidateServer(s); err != nil {
+			t.Fatalf("expected no error for empty optional fields, got: %v", err)
+		}
+	})
+
+	requiredFieldCases := []struct {
+		name      string
+		mutate    func(*models.ObaServer)
+		wantField string
+	}{
+		{"missing gtfs_url", func(s *models.ObaServer) { s.GtfsUrl = "" }, "gtfs_url"},
+		{"missing vehicle_position_url", func(s *models.ObaServer) { s.VehiclePositionUrl = "" }, "vehicle_position_url"},
+		{"missing oba_base_url", func(s *models.ObaServer) { s.ObaBaseURL = "" }, "oba_base_url"},
+		{"missing oba_api_key", func(s *models.ObaServer) { s.ObaApiKey = "" }, "oba_api_key"},
+		{"missing agency_id", func(s *models.ObaServer) { s.AgencyID = "" }, "agency_id"},
+		{"missing name", func(s *models.ObaServer) { s.Name = "" }, "name"},
+		{"missing id", func(s *models.ObaServer) { s.ID = 0 }, "id"},
+		{"whitespace-only agency_id", func(s *models.ObaServer) { s.AgencyID = "   " }, "agency_id"},
+		{"whitespace-only gtfs_url", func(s *models.ObaServer) { s.GtfsUrl = "  \t " }, "gtfs_url"},
+	}
+
+	for _, tc := range requiredFieldCases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := validServer()
+			tc.mutate(&s)
+			err := ValidateServer(s)
+			if err == nil {
+				t.Fatalf("expected error for %s, got nil", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.wantField) {
+				t.Fatalf("expected error to mention %q, got: %v", tc.wantField, err)
+			}
+		})
+	}
+
+	t.Run("reports all missing fields at once", func(t *testing.T) {
+		// Mirrors the production config where every feed field was null.
+		s := models.ObaServer{
+			Name:       "Intercity Transit",
+			ID:         33,
+			ObaBaseURL: "https://intercity-transit-oba-server.onrender.com",
+			ObaApiKey:  "org.onebusaway.iphone",
+		}
+		err := ValidateServer(s)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		for _, field := range []string{"gtfs_url", "vehicle_position_url", "agency_id"} {
+			if !strings.Contains(err.Error(), field) {
+				t.Fatalf("expected error to mention %q, got: %v", field, err)
+			}
+		}
+	})
+}
+
+// loadConfigFromFile must drop servers that fail validation (e.g. the
+// production config where every feed URL was null) while keeping the valid
+// ones, so one bad entry can't take down monitoring for the whole fleet.
+func TestLoadConfigFromFileFiltersInvalidServers(t *testing.T) {
+	content := `[
+		{
+			"name": "Valid Server", "id": 1,
+			"oba_base_url": "https://valid.example.com",
+			"oba_api_key": "valid-key",
+			"gtfs_url": "https://gtfs.example.com",
+			"vehicle_position_url": "https://vehicle.example.com",
+			"agency_id": "agency-1"
+		},
+		{
+			"name": "Broken Server", "id": 2,
+			"oba_base_url": "https://broken.example.com",
+			"oba_api_key": "broken-key",
+			"gtfs_url": null,
+			"vehicle_position_url": null,
+			"agency_id": null
+		}
+	]`
+
+	dir := t.TempDir()
+	fp := filepath.Join(dir, "config.json")
+	if err := os.WriteFile(fp, []byte(content), 0o600); err != nil {
+		t.Fatalf("write config.json: %v", err)
+	}
+
+	servers, err := loadConfigFromFile(fp)
+	if err != nil {
+		t.Fatalf("loadConfigFromFile failed: %v", err)
+	}
+
+	if len(servers) != 1 {
+		t.Fatalf("expected 1 valid server, got %d: %+v", len(servers), servers)
+	}
+	if servers[0].ID != 1 {
+		t.Fatalf("expected the valid server (id 1) to be kept, got id %d", servers[0].ID)
+	}
+}
+
+// loadConfigFromURL is an independent call site from loadConfigFromFile and is
+// the production path (remote config + periodic refresh), so it needs its own
+// coverage that invalid servers are filtered out.
+func TestLoadConfigFromURLFiltersInvalidServers(t *testing.T) {
+	body := `[
+		{
+			"name": "Valid Server", "id": 1,
+			"oba_base_url": "https://valid.example.com",
+			"oba_api_key": "valid-key",
+			"gtfs_url": "https://gtfs.example.com",
+			"vehicle_position_url": "https://vehicle.example.com",
+			"agency_id": "agency-1"
+		},
+		{
+			"name": "Broken Server", "id": 2,
+			"oba_base_url": "https://broken.example.com",
+			"oba_api_key": "broken-key",
+			"gtfs_url": null,
+			"vehicle_position_url": null,
+			"agency_id": null
+		}
+	]`
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(body))
+	}))
+	defer ts.Close()
+
+	servers, err := loadConfigFromURL(context.Background(), &http.Client{Timeout: 10 * time.Second}, ts.URL, "", "", 1)
+	if err != nil {
+		t.Fatalf("loadConfigFromURL failed: %v", err)
+	}
+
+	if len(servers) != 1 || servers[0].ID != 1 {
+		t.Fatalf("expected only the valid server (id 1), got %+v", servers)
+	}
+}
+
+func TestFilterValidServers(t *testing.T) {
+	t.Run("drops every invalid server and preserves the order of valid ones", func(t *testing.T) {
+		valid1 := validServer()
+		valid1.ID = 1
+		valid2 := validServer()
+		valid2.ID = 2
+		invalidA := validServer()
+		invalidA.ID = 10
+		invalidA.GtfsUrl = ""
+		invalidB := validServer()
+		invalidB.ID = 11
+		invalidB.AgencyID = ""
+
+		// Interleave valid and invalid: valid, invalid, valid, invalid.
+		got := filterValidServers([]models.ObaServer{valid1, invalidA, valid2, invalidB})
+
+		if len(got) != 2 {
+			t.Fatalf("expected 2 valid servers, got %d: %+v", len(got), got)
+		}
+		if got[0].ID != 1 || got[1].ID != 2 {
+			t.Fatalf("expected valid servers kept in order (1, 2), got (%d, %d)", got[0].ID, got[1].ID)
+		}
+	})
+
+	t.Run("all servers invalid yields an empty slice", func(t *testing.T) {
+		bad := validServer()
+		bad.GtfsUrl = ""
+		got := filterValidServers([]models.ObaServer{bad})
+		if len(got) != 0 {
+			t.Fatalf("expected 0 valid servers, got %d", len(got))
+		}
+	})
+
+	t.Run("empty input yields an empty slice", func(t *testing.T) {
+		got := filterValidServers(nil)
+		if len(got) != 0 {
+			t.Fatalf("expected 0 servers, got %d", len(got))
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- Fixes the production failure where the service-discovery file had `null` feed URLs (`gtfs_url`, `vehicle_position_url`, `agency_id`). Go unmarshals JSON `null` into a string field as `""`, which produced cryptic `Get "": unsupported protocol scheme ""` errors on **every** fetch cycle for the affected servers (33, 41, 43, 36, 19).
- Adds `ValidateServer` (required: `id`, `name`, `oba_base_url`, `oba_api_key`, `gtfs_url`, `vehicle_position_url`, `agency_id`; `trip_update_url` and the GTFS-RT auth pair are optional) and `filterValidServers`, which drops invalid servers and reports each to Sentry — one bad entry can't block monitoring of the rest of the fleet. Wired into both `loadConfigFromFile` and `loadConfigFromURL`, so it covers startup **and** the periodic remote-config refresh.
- Initializes Sentry **before** loading config in `main.go`. Previously config load/validation ran ~30 lines before `SetupSentry()`, so startup-time error reports were captured by an uninitialized hub and silently lost — exactly the partial-misconfig case this fix targets.
- Also includes the earlier `CLAUDE.md` commit already on this branch.

## Test plan
- [x] `go test ./...` — full suite green
- [x] New unit tests: `ValidateServer` (valid, each required field, whitespace-only, all-missing production mirror), `filterValidServers` (interleaved valid/invalid ordering, all-invalid, empty), and filtering coverage for **both** the file and URL loaders
- [x] Ran the binary against a config mirroring the prod failure (one all-null server + one well-formed): the broken server is filtered out with no `unsupported protocol scheme` error; the well-formed server flows through normally
- [x] Ran with an all-invalid config: clean exit with `No servers found in configuration.`
- [x] `go vet ./...` clean, `gofmt` clean, binary builds with `CGO_ENABLED=0`

## Review notes (non-blocking)
- **Drop severity / aggregate signal:** each dropped server is reported at `sentry.LevelError` (consistent with the loaders' existing reports). A reviewer may prefer `LevelWarning` for routine single-entry drops, plus a single summary signal that conveys the *ratio* dropped (e.g. "45 of 50") so a near-total config collapse is distinguishable from one bad entry. Left as-is to match current package conventions.
- **Log visibility:** the loaders have no `*slog.Logger`, so drops are reported only to Sentry, not the structured logs. Surfacing a "loaded N of M servers, dropped K" summary via the logger in `main.go`/`refreshConfig` (which do hold loggers) would require threading a drop count back out of the loaders — deferred to keep this PR scoped.
- The real upstream fix is whatever **generates** the service-discovery file: it should emit real feed URLs instead of `null`. This PR makes watchdog resilient to that input but doesn't fix the generator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server configuration validation to filter out invalid server entries before they’re used, reducing runtime misconfiguration issues and improving monitoring of bad configs.
  * Enhanced startup monitoring by initializing error reporting earlier to better capture failures.
* **Documentation**
  * Added repository guidance for running common development, testing, and CI workflows.
* **Tests**
  * Added unit tests covering server validation, config loading/filtering, and refreshed configuration payload handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->