### PR TITLE
feat(dashboard): set Agency Consistency visualization to Table

### DIFF
--- a/grafana/dashboards/watchdog_metrics_dashboard.json
+++ b/grafana/dashboards/watchdog_metrics_dashboard.json
@@ -202,7 +202,71 @@
       "datasource": {
         "name": "Prometheus"
       },
-      "description": "Metrics: oba_agencies_in_static_gtfs, oba_agencies_in_coverage_endpoint, oba_agencies_match\nQuestion answered: \"Does the coverage endpoint match the static GTFS dataset?\"",
+      "description": "Metrics: oba_agencies_in_static_gtfs, oba_agencies_in_coverage_endpoint, oba_agencies_match\nQuestion answered: \"Does the coverage endpoint match the static GTFS dataset?\"\n\nVisualization: Table\nRationale: When comparing static GTFS arrays against the live coverage endpoint, operators need to know exactly *which* agency is missing to debug the failure. A table explicitly listing the mismatched items provides an immediate, actionable checklist for engineering.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Match Status"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "basic",
+                  "type": "color-background"
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "0": {
+                        "color": "red",
+                        "index": 0,
+                        "text": "MISMATCH"
+                      },
+                      "1": {
+                        "color": "green",
+                        "index": 1,
+                        "text": "OK"
+                      }
+                    },
+                    "type": "value"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
       "gridPos": {
         "h": 8,
         "w": 12,
@@ -210,31 +274,50 @@
         "y": 10
       },
       "id": 202,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": true,
+          "enablePagination": false,
+          "fields": "",
+          "reducer": ["count"],
+          "show": true
+        },
+        "showHeader": true,
+        "sortBy": []
+      },
+      "pluginVersion": "13.0.2",
       "targets": [
         {
           "expr": "oba_agencies_in_static_gtfs{server_id=~\"$server_id\"}",
+          "legendFormat": "Static GTFS",
           "refId": "A",
           "datasource": {
             "name": "Prometheus"
-          }
+          },
+          "instant": true
         },
         {
           "expr": "oba_agencies_in_coverage_endpoint{server_id=~\"$server_id\"}",
+          "legendFormat": "Coverage Endpoint",
           "refId": "B",
           "datasource": {
             "name": "Prometheus"
-          }
+          },
+          "instant": true
         },
         {
           "expr": "oba_agencies_match{server_id=~\"$server_id\"}",
+          "legendFormat": "Match Status",
           "refId": "C",
           "datasource": {
             "name": "Prometheus"
-          }
+          },
+          "instant": true
         }
       ],
       "title": "2.2 Agency Consistency",
-      "type": "timeseries"
+      "type": "table"
     },
     {
       "collapsed": false,


### PR DESCRIPTION
Fixes #99

### Design Decisions Summary

**Grouping & Panel Choice:**
Grouped under "Static GTFS Health", the default timeseries made it difficult to identify *which* specific agencies were failing to match between endpoints.

**Visualization Rationale:**
I chose a **Table** visualization. When comparing static GTFS arrays against the live coverage endpoint, operators need to know exactly which agency is missing to debug the failure. A table explicitly listing the agencies and mapping them to "OK" or "MISMATCH" cells provides an immediate, actionable checklist for engineering.

**Go Metric Modifications:**
No Go metric types were modified.
