### PR TITLE
feat(dashboard): set Stop Matching visualization to Bar Gauge

### DIFF
--- a/grafana/dashboards/watchdog_metrics_dashboard.json
+++ b/grafana/dashboards/watchdog_metrics_dashboard.json
@@ -428,7 +428,7 @@
       "datasource": {
         "name": "Prometheus"
       },
-      "description": "Metrics: oba_stops_matched_count, oba_stops_unmatched_count, oba_stop_match_ratio\nQuestion answered: \"Are stop mappings degrading?\"\n\nVisualization: Bar Gauge\nRationale: A ranking bar gauge sorted by worst agencies first allows operators to immediately triage the most problematic feeds. The gradient color (green to red) makes it visually obvious which stops need attention.",
+      "description": "Metric: oba_stop_match_ratio\nQuestion answered: \"Which agencies have the worst stop mapping quality?\"\n\nVisualization: Bar Gauge\nRationale: A ranking bar gauge sorted by worst agencies first allows operators to immediately triage the most problematic feeds. The gradient color (green to red) makes it visually obvious which stops need attention.",
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/grafana/dashboards/watchdog_metrics_dashboard.json
+++ b/grafana/dashboards/watchdog_metrics_dashboard.json
@@ -428,7 +428,35 @@
       "datasource": {
         "name": "Prometheus"
       },
-      "description": "Metrics: oba_stops_matched_count, oba_stops_unmatched_count, oba_stop_match_ratio\nQuestion answered: \"Are stop mappings degrading?\"",
+      "description": "Metrics: oba_stops_matched_count, oba_stops_unmatched_count, oba_stop_match_ratio\nQuestion answered: \"Are stop mappings degrading?\"\n\nVisualization: Bar Gauge\nRationale: A ranking bar gauge sorted by worst agencies first allows operators to immediately triage the most problematic feeds. The gradient color (green to red) makes it visually obvious which stops need attention.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.7
+              },
+              {
+                "color": "green",
+                "value": 0.9
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
       "gridPos": {
         "h": 8,
         "w": 8,
@@ -436,31 +464,35 @@
         "y": 36
       },
       "id": 402,
+      "options": {
+        "displayMode": "gradient",
+        "maxVizHeight": 300,
+        "minVizHeight": 16,
+        "minVizWidth": 75,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "pluginVersion": "13.0.2",
       "targets": [
         {
-          "expr": "oba_stops_matched_count{server=~\"$server_id\", agency=~\"$agency_id\"}",
-          "refId": "A",
-          "datasource": {
-            "name": "Prometheus"
-          }
-        },
-        {
-          "expr": "oba_stops_unmatched_count{server=~\"$server_id\", agency=~\"$agency_id\"}",
-          "refId": "B",
-          "datasource": {
-            "name": "Prometheus"
-          }
-        },
-        {
           "expr": "oba_stop_match_ratio{server=~\"$server_id\", agency=~\"$agency_id\"}",
-          "refId": "C",
+          "legendFormat": "{{agency}} (Server {{server}})",
+          "refId": "A",
           "datasource": {
             "name": "Prometheus"
           }
         }
       ],
       "title": "4.2 Stop Matching",
-      "type": "timeseries"
+      "type": "bargauge"
     },
     {
       "datasource": {


### PR DESCRIPTION
Fixes #105

### Design Decisions Summary

**Grouping & Panel Choice:**
Grouped under "Matching Quality", the default timeseries made it difficult to quickly rank or triage which agencies were experiencing the worst stop mismatch degradation.

**Visualization Rationale:**
I chose a horizontal **Bar Gauge**. A ranking bar gauge sorted by worst agencies first allows operators to immediately triage the most problematic feeds. The gradient color (green to red thresholds) makes it visually obvious which stops need immediate attention.

**Go Metric Modifications:**
No Go metric types were modified.
