### PR TITLE
feat(dashboard): set Dependency Latency visualization to Heatmap

### DIFF
--- a/grafana/dashboards/watchdog_metrics_dashboard.json
+++ b/grafana/dashboards/watchdog_metrics_dashboard.json
@@ -195,7 +195,7 @@
       "pluginVersion": "13.0.2",
       "targets": [
         {
-          "expr": "sum(rate(http_outgoing_request_duration_seconds_bucket{url=~\".*\"}[5m])) by (le)",
+          "expr": "sum(rate(http_outgoing_request_duration_seconds_bucket{server_id=~\"$server_id\"}[5m])) by (le)",
           "format": "heatmap",
           "legendFormat": "{{le}}",
           "refId": "A",

--- a/grafana/dashboards/watchdog_metrics_dashboard.json
+++ b/grafana/dashboards/watchdog_metrics_dashboard.json
@@ -134,7 +134,22 @@
       "datasource": {
         "name": "Prometheus"
       },
-      "description": "Metrics: http_outgoing_request_duration_seconds\nQuestion answered: \"Are external dependencies becoming slow?\"",
+      "description": "Metrics: http_outgoing_request_duration_seconds\nQuestion answered: \"Are external dependencies becoming slow?\"\n\nVisualization: Heatmap\nRationale: Latency is a distribution, not a single average. A heatmap visualizes the distribution of request durations over time, making it easy to instantly spot bimodal patterns and long-tail outliers (like degraded downstream servers) that a simple line chart would compress or hide.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          }
+        },
+        "overrides": []
+      },
       "gridPos": {
         "h": 8,
         "w": 12,
@@ -142,9 +157,47 @@
         "y": 1
       },
       "id": 102,
+      "options": {
+        "calculate": true,
+        "cellGap": 1,
+        "color": {
+          "exponent": 0.5,
+          "fill": "dark-orange",
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "Oranges",
+          "steps": 64
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-9
+        },
+        "legend": {
+          "show": true
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "tooltip": {
+          "mode": "single",
+          "showColorScale": false,
+          "yHistogram": true
+        },
+        "yAxis": {
+          "axisPlacement": "left",
+          "reverse": false,
+          "unit": "s"
+        }
+      },
+      "pluginVersion": "13.0.2",
       "targets": [
         {
-          "expr": "http_outgoing_request_duration_seconds_sum",
+          "expr": "sum(rate(http_outgoing_request_duration_seconds_bucket{url=~\".*\"}[5m])) by (le)",
+          "format": "heatmap",
+          "legendFormat": "{{le}}",
           "refId": "A",
           "datasource": {
             "name": "Prometheus"
@@ -152,7 +205,7 @@
         }
       ],
       "title": "1.2 Dependency Latency",
-      "type": "timeseries"
+      "type": "heatmap"
     },
     {
       "collapsed": false,

--- a/grafana/dashboards/watchdog_metrics_dashboard.json
+++ b/grafana/dashboards/watchdog_metrics_dashboard.json
@@ -158,7 +158,7 @@
       },
       "id": 102,
       "options": {
-        "calculate": true,
+        "calculate": false,
         "cellGap": 1,
         "color": {
           "exponent": 0.5,


### PR DESCRIPTION
Fixes #97

### Design Decisions Summary

**Grouping & Panel Choice:**
This metric remains correctly grouped under "System Availability", but the default timeseries panel compressed request duration distributions into a single line, masking bimodal patterns.

**Visualization Rationale:**
I chose a **Heatmap** for this panel. Latency is fundamentally a distribution, not a single average. A heatmap visualizes the distribution of request durations over time, making it easy to instantly spot long-tail outliers (like degraded downstream servers) that a simple line chart would hide. 

**Go Metric Modifications:**
No Go metric types were modified. However, the PromQL query was updated to use `sum(rate(http_outgoing_request_duration_seconds_bucket[5m])) by (le)` to properly feed the heatmap.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the Dependency Latency dashboard panel to display request latency as a heatmap.
  * Added clearer bucket-based visualization and histogram tooltips for easier latency analysis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->