### PR TITLE
feat: automate version injection and release pipeline

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,10 @@ WORKDIR /usr/src/app
 COPY go.mod go.sum ./
 RUN go mod download && go mod verify
 
+ARG VERSION=dev
+
 COPY . .
-RUN CGO_ENABLED=0 go build -v -o . ./...
+RUN CGO_ENABLED=0 go build -v -ldflags="-X main.version=${VERSION}" -o . ./...
 
 # Final stage
 FROM debian:bookworm-slim

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,11 @@
+VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+LDFLAGS := -ldflags="-X main.version=$(VERSION)"
+
 compile:
-	CGO_ENABLED=0 go build -v -o . ./...
+	CGO_ENABLED=0 go build -v $(LDFLAGS) -o . ./...
 
 docker:
-	docker build -t watchdog .
+	docker build --build-arg VERSION=$(VERSION) -t watchdog .
 
 fmt:
 	gofmt -w .

--- a/cmd/watchdog/main.go
+++ b/cmd/watchdog/main.go
@@ -21,6 +21,24 @@ import (
 var version = "dev"
 
 func main() {
+	var cfg config.Config
+
+	flag.IntVar(&cfg.Port, "port", 4000, "API server port")
+	flag.StringVar(&cfg.Env, "env", "development", "Environment (development|staging|production)")
+	flag.IntVar(&cfg.FetchInterval, "fetch-interval", 30, "Interval (in seconds) at which the application fetches data from realtime APIs and updates Prometheus metrics")
+
+	var (
+		showVersion = flag.Bool("version", false, "display version and exit")
+		configFile  = flag.String("config-file", "", "Path to a local JSON configuration file")
+		configURL   = flag.String("config-url", "", "URL to a remote JSON configuration file")
+	)
+	flag.Parse()
+
+	if *showVersion {
+		fmt.Println(version)
+		os.Exit(0)
+	}
+
 	// Initialize a structured logger for the application
 	// This logger will be used throughout the application for logging messages.
 	// It can be configured to log to different outputs (e.g., console, file)
@@ -29,21 +47,6 @@ func main() {
 	// Load environment variables for configuration
 	configAuthUser := os.Getenv("CONFIG_AUTH_USER")
 	configAuthPass := os.Getenv("CONFIG_AUTH_PASS")
-
-	// Initialize the application configuration with default values
-	// These values can be overridden by command line flags or environment variables.
-	var cfg config.Config
-
-	flag.IntVar(&cfg.Port, "port", 4000, "API server port")
-	flag.StringVar(&cfg.Env, "env", "development", "Environment (development|staging|production)")
-	flag.IntVar(&cfg.FetchInterval, "fetch-interval", 30, "Interval (in seconds) at which the application fetches data from realtime APIs and updates Prometheus metrics")
-
-	var (
-		configFile = flag.String("config-file", "", "Path to a local JSON configuration file")
-		configURL  = flag.String("config-url", "", "URL to a remote JSON configuration file")
-	)
-	// Parse command line flags
-	flag.Parse()
 
 	// Validate that only one configuration source is specified
 	// Either a config file or a remote config URL can be specified, but not both.

--- a/cmd/watchdog/main.go
+++ b/cmd/watchdog/main.go
@@ -16,10 +16,9 @@ import (
 	"watchdog.onebusaway.org/internal/report"
 )
 
-// Declare a string containing the application version number. Later in the book we'll
-// generate this automatically at build time, but for now we'll just store the version
-// number as a hard-coded global constant.
-const version = "1.0.0"
+// Application version injected at build time via ldflags.
+// Defaults to "dev" when built without ldflags (e.g., go run).
+var version = "dev"
 
 func main() {
 	// Initialize a structured logger for the application


### PR DESCRIPTION
## PR Description:
Replaces the hardcoded version constant with a linker-injected variable derived from Git tags, and adds a --version flag for easy version inspection.
- Replace const version = "1.0.0" with var version = "dev" injectable via -ldflags
- Update Makefile to derive VERSION from git describe and pass it to the build
- Update Dockerfile to accept VERSION as a build arg and inject via ldflags
- Add --version flag that prints the injected version and exits

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `-version` flag to display the app version and exit.
  * Application builds now include an identifiable version, shown in startup logs and error reporting when available.
  * Builds without version metadata fall back to `dev`.
* **Chores**
  * Build and container workflows now derive version data automatically and pass it through to the compiled binary.
  * Build workflow now runs `go vet ./...` for added Go validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->