### PR TITLE
feat: inject release tag as app version in Docker build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -98,6 +98,7 @@ jobs:
           context: .  # Path to the directory containing the Dockerfile
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
+          build-args: VERSION=${{ env.IMAGE_TAG }}
           tags: |
             opentransitsoftwarefoundation/watchdog:latest
             opentransitsoftwarefoundation/watchdog:${{ env.IMAGE_TAG }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker image builds to include the release version during the build process.
  * No other release workflow behavior was changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->