### PR TITLE
fix: metric type naming to follow prometheus conventions 

### DIFF
--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -93,7 +93,7 @@ Metrics follow [Prometheus naming conventions](https://prometheus.io/docs/practi
 | `oba_realtime_trip_match_ratio`      | Gauge | `server`, `agency`                                       | ratio   | Ratio of matched realtime trips to total trips.    |
 | `oba_stop_match_ratio`               | Gauge | `server`, `agency`                                       | ratio   | Ratio of matched stops to total stops.             |
 | `oba_time_since_last_update_seconds` | Gauge | `server`, `agency`                                       | seconds | Time since last realtime update.                   |
-| `oba_unmatched_stop_location`        | Gauge | `server`, `agency`, `stop_id`, `stop_name`, `lat`, `lon` | N/A     | Location info of unmatched stops from static GTFS. |
+| `oba_unmatched_stop_info`            | Gauge | `server`, `agency`, `stop_id`, `stop_name`, `lat`, `lon` | N/A     | Presence marker (always 1) for unmatched stops from static GTFS, with location as labels. |
 | `oba_unmatched_stop_cluster_count`   | Gauge | `server`, `agency`, `cluster_id`, `cluster_type`         | count   | Number of unmatched stops grouped by cluster.      |
 
 **Interpretation Guide:**

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -84,7 +84,7 @@ Metrics follow [Prometheus naming conventions](https://prometheus.io/docs/practi
 | Metric Name                          | Type  | Labels                                                   | Unit    | Description                                        |
 | ------------------------------------ | ----- | -------------------------------------------------------- | ------- | -------------------------------------------------- |
 | `oba_agencies_with_coverage_count`   | Gauge | `server`                                                 | count   | Number of agencies with coverage.                  |
-| `oba_realtime_records_total`         | Gauge | `server`, `agency`                                       | count   | Total realtime records received.                   |
+| `oba_realtime_records_count`         | Gauge | `server`, `agency`                                       | count   | Total realtime records received.                   |
 | `oba_realtime_trips_matched_count`   | Gauge | `server`, `agency`                                       | count   | Number of matched realtime trips.                  |
 | `oba_realtime_trips_unmatched_count` | Gauge | `server`, `agency`                                       | count   | Number of unmatched realtime trips.                |
 | `oba_scheduled_trips_count`          | Gauge | `server`, `agency`                                       | count   | Number of scheduled trips.                         |

--- a/grafana/dashboards/watchdog_metrics_dashboard.json
+++ b/grafana/dashboards/watchdog_metrics_dashboard.json
@@ -383,7 +383,7 @@
       "datasource": {
         "name": "Prometheus"
       },
-      "description": "Metrics: oba_realtime_records_total, oba_realtime_trips_matched_count, oba_realtime_trips_unmatched_count, oba_realtime_trip_match_ratio\nQuestion answered: \"How much realtime trip data is usable?\"",
+      "description": "Metrics: oba_realtime_records_count, oba_realtime_trips_matched_count, oba_realtime_trips_unmatched_count, oba_realtime_trip_match_ratio\nQuestion answered: \"How much realtime trip data is usable?\"",
       "gridPos": {
         "h": 8,
         "w": 8,
@@ -393,7 +393,7 @@
       "id": 401,
       "targets": [
         {
-          "expr": "oba_realtime_records_total{server=~\"$server_id\", agency=~\"$agency_id\"}",
+          "expr": "oba_realtime_records_count{server=~\"$server_id\", agency=~\"$agency_id\"}",
           "refId": "A",
           "datasource": {
             "name": "Prometheus"

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -123,7 +123,7 @@ var (
 
 	ObaRealtimeRecords = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "oba_realtime_records_total",
+			Name: "oba_realtime_records_count",
 			Help: "Total number of realtime records",
 		},
 		[]string{"server", "agency"},

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -187,10 +187,10 @@ var (
 		[]string{"server", "agency"},
 	)
 
-	ObaUnmatchedStopLocation = promauto.NewGaugeVec(
+	ObaUnmatchedStopInfo = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "oba_unmatched_stop_location",
-			Help: "Location info of unmatched stops from static GTFS",
+			Name: "oba_unmatched_stop_info",
+			Help: "Presence marker (always 1) for unmatched stops from static GTFS with their location as labels",
 		},
 		[]string{"server", "agency", "stop_id", "stop_name", "lat", "lon"},
 	)

--- a/internal/metrics/oba_rest_api_metrics.go
+++ b/internal/metrics/oba_rest_api_metrics.go
@@ -178,7 +178,7 @@ func fetchObaAPIMetrics(slugID string, serverID int, serverBaseUrl string, apiKe
 				if stop.Latitude == nil || stop.Longitude == nil {
 					continue
 				}
-				ObaUnmatchedStopLocation.WithLabelValues(
+				ObaUnmatchedStopInfo.WithLabelValues(
 					slugID,
 					agencyID,
 					stopID,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Metrics**
  * Renamed realtime record metrics for clearer reporting.
  * Updated unmatched-stop metrics to use an always-1 presence marker with location labels.
  * Updated monitoring dashboards and metric documentation to reflect the new names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->