### PR TITLE
feat(prometheus): add operational alerting rules

### DIFF
--- a/prometheus/rules/operational.yml
+++ b/prometheus/rules/operational.yml
@@ -1,0 +1,23 @@
+groups:
+  - name: watchdog-operational
+    rules:
+      - alert: ObaAPIDown
+        expr: oba_api_status == 0
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "OneBusAway API unavailable for {{ $labels.server_name }}"
+          description: >-
+            The OneBusAway API at {{ $labels.server_url }} has reported
+            unavailable for 2m+ (oba_api_status={{ $value }}).
+      - alert: GTFSBundleExpiringSoon
+        expr: gtfs_bundle_days_until_earliest_expiration < 3
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "GTFS bundle expiring soon for {{ $labels.agency_name }} ({{ $labels.agency_id }})"
+          description: >-
+            The earliest GTFS bundle for {{ $labels.agency_name }} ({{ $labels.agency_id }})
+            at {{ $labels.server_url }} expires in {{ $value }} days, below the 3-day threshold.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated bounding-box validation guidance for `gtfs_rt_stopped_out_of_bounds_vehicles`.
  - Clarified that vehicles associated with an agency are checked against that agency’s bounding box.
  - Vehicles without a resolved agency continue to use the server-wide union bounding box.
  - Documented that the empty-`agency_id` series represents a looser bound than per-agency series.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->